### PR TITLE
feat: ARIMA 예측 모델 통합 및 데이터 파이프라인 구축

### DIFF
--- a/arima_handler.py
+++ b/arima_handler.py
@@ -1,0 +1,45 @@
+"""
+ARIMA 배치 예측 Lambda 핸들러.
+매월 1일 10:00 KST (01:00 UTC) 실행.
+"""
+import json
+from datetime import datetime
+
+
+def lambda_handler(event, context):
+    print(f"ARIMA 배치 시작: {datetime.now().isoformat()}")
+
+    try:
+        from src.services.arima_service import get_arima_service
+
+        service = get_arima_service()
+        result = service.run_batch()
+
+        symbols_count = result['symbol'].nunique() if 'symbol' in result.columns else 0
+        rows_count = len(result)
+
+        response = {
+            'statusCode': 200,
+            'body': json.dumps({
+                'message': 'ARIMA batch prediction completed',
+                'symbols': symbols_count,
+                'rows': rows_count,
+                'timestamp': datetime.now().isoformat()
+            })
+        }
+        print(f"ARIMA 배치 완료: {symbols_count} 종목, {rows_count} 행")
+        return response
+
+    except Exception as e:
+        print(f"ARIMA 배치 실패: {e}")
+        import traceback
+        traceback.print_exc()
+
+        return {
+            'statusCode': 500,
+            'body': json.dumps({
+                'message': 'ARIMA batch prediction failed',
+                'error': str(e),
+                'timestamp': datetime.now().isoformat()
+            })
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ boto3==1.34.34
 email-validator
 requests
 anthropic==0.39.0
+statsmodels>=0.14.0
+pandas>=2.0.0
+numpy>=1.24.0

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -2,11 +2,13 @@ from fastapi import APIRouter
 from .signals import router as signals_router
 from .reports import router as reports_router
 from .subscribe import router as subscribe_router
+from .predict import router as predict_router
 
 api_router = APIRouter()
 
 api_router.include_router(signals_router)
 api_router.include_router(reports_router)
 api_router.include_router(subscribe_router)
+api_router.include_router(predict_router)
 
 __all__ = ["api_router"]

--- a/src/api/predict.py
+++ b/src/api/predict.py
@@ -1,0 +1,124 @@
+from fastapi import APIRouter, BackgroundTasks
+from datetime import datetime
+from typing import Optional
+from ..schemas import ApiResponse
+
+router = APIRouter(prefix="/predict", tags=["predict"])
+
+# 마지막 예측 실행 상태
+_last_run = {
+    "status": "never_run",
+    "started_at": None,
+    "completed_at": None,
+    "symbols_count": 0,
+    "rows_count": 0,
+    "error": None,
+}
+
+
+def _run_arima_batch():
+    """ARIMA 배치 실행 (BackgroundTasks용)"""
+    global _last_run
+    _last_run["status"] = "running"
+    _last_run["started_at"] = datetime.now().isoformat()
+    _last_run["error"] = None
+
+    try:
+        from ..services.arima_service import get_arima_service
+        service = get_arima_service()
+        result = service.run_batch()
+
+        _last_run["status"] = "completed"
+        _last_run["completed_at"] = datetime.now().isoformat()
+        _last_run["symbols_count"] = result['symbol'].nunique() if 'symbol' in result.columns else 0
+        _last_run["rows_count"] = len(result)
+        print(f"ARIMA 배치 완료: {_last_run['symbols_count']} 종목, {_last_run['rows_count']} 행")
+    except Exception as e:
+        _last_run["status"] = "failed"
+        _last_run["completed_at"] = datetime.now().isoformat()
+        _last_run["error"] = str(e)
+        print(f"ARIMA 배치 실패: {e}")
+
+
+@router.post("/run")
+async def run_prediction(background_tasks: BackgroundTasks):
+    """
+    ARIMA 배치 예측 수동 실행.
+    백그라운드로 실행되며 /status로 진행 상태 확인 가능.
+    """
+    if _last_run["status"] == "running":
+        return ApiResponse(
+            success=False,
+            data={"message": "이미 예측이 실행 중입니다", "status": _last_run},
+            error="ALREADY_RUNNING"
+        )
+
+    background_tasks.add_task(_run_arima_batch)
+
+    return ApiResponse(
+        success=True,
+        data={
+            "message": "ARIMA 배치 예측이 시작되었습니다",
+            "started_at": datetime.now().isoformat()
+        }
+    )
+
+
+@router.get("/status")
+async def get_prediction_status():
+    """마지막 예측 실행 시간/상태 조회"""
+    return ApiResponse(success=True, data=_last_run)
+
+
+@router.get("/latest")
+async def get_latest_predictions(
+    symbol: Optional[str] = None,
+    limit: int = 50
+):
+    """
+    최신 ARIMA 예측 결과 조회.
+
+    Args:
+        symbol: 특정 종목 필터 (없으면 전체)
+        limit: 결과 개수 제한
+    """
+    try:
+        from ..services.arima_service import get_arima_service
+        service = get_arima_service()
+        df = service.load_latest_predictions()
+
+        if df is None:
+            return ApiResponse(
+                success=True,
+                data={
+                    "predictions": [],
+                    "message": "아직 ARIMA 예측 결과가 없습니다. POST /api/predict/run으로 실행하세요.",
+                    "count": 0
+                }
+            )
+
+        if symbol:
+            df = df[df['symbol'].astype(str).str.strip() == symbol]
+
+        # 최신 날짜만
+        if 'date' in df.columns:
+            latest_date = df['date'].max()
+            df = df[df['date'] == latest_date]
+
+        records = df.head(limit).to_dict('records')
+
+        return ApiResponse(
+            success=True,
+            data={
+                "predictions": records,
+                "count": len(records),
+                "latest_date": str(latest_date) if 'date' in df.columns else None
+            }
+        )
+
+    except Exception as e:
+        return ApiResponse(
+            success=False,
+            data={"predictions": [], "count": 0},
+            error=str(e)
+        )

--- a/src/api/signals.py
+++ b/src/api/signals.py
@@ -12,13 +12,13 @@ async def get_signals(
     limit: int = Query(20, ge=1, le=100, description="결과 개수")
 ):
     """
-    최신 트레이딩 시그널 조회 (기간별 예측 지원)
-    
+    최신 트레이딩 시그널 조회 (ARIMA 예측 + v5 5-Factor 규칙 기반)
+
     - **period**: 1d(1일), 5d(5일), 10d(10일), 20d(20일)
+    - ARIMA 예측 결과가 있으면 모델 기반 판단, 없으면 정적 CSV 폴백
     """
-    
+
     try:
-        # 실제 ML 모델 사용 (기간 파라미터 추가)
         predictor = get_predictor()
         raw_signals = predictor.get_top_signals(limit=limit, period=period)
         

--- a/src/schemas/signal.py
+++ b/src/schemas/signal.py
@@ -7,12 +7,14 @@ class TradingSignal(BaseModel):
     symbol: str
     companyName: str
     sector: str
-    signalType: str  # "BUY" | "SELL"
-    yoyGrowth: float  # YoY 유지
-    # momGrowth 제거!
+    signalType: str  # "BUY" | "HOLD" | "SELL"
+    surpriseZ: Optional[float] = 0.0
+    yoyGrowth: float
     expectedReturn: float
+    vsKospi: Optional[float] = 0.0
+    kospiReturn: Optional[float] = 0.0
     confidenceScore: float
-    period: Optional[str] = "1d"  # 기간 추가
+    period: Optional[str] = "1d"
 
 class PerformanceMetrics(BaseModel):
     avgReturn: float

--- a/src/services/arima_service.py
+++ b/src/services/arima_service.py
@@ -1,0 +1,228 @@
+import os
+import csv
+import numpy as np
+import pandas as pd
+import boto3
+from io import StringIO
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# mg-data 분석 결과 기반 최적 하이퍼파라미터
+ARIMA_ORDER = (1, 2, 1)
+REFIT_EVERY = 3
+Z_THRESHOLD = 2.0
+
+
+class ARIMASurpriseService:
+    """
+    ARIMA 기반 수출 서프라이즈 예측 서비스.
+    mg-data problem1_surprise.ipynb에서 추출한 SARIMAX(1,2,1) 로직.
+    """
+
+    def __init__(self):
+        self.use_s3 = os.environ.get('USE_S3_DATA', 'false').lower() == 'true'
+        self.s3_bucket = os.environ.get('S3_DATA_BUCKET', 'stockplay-data-yjw-20251113')
+        self.order = ARIMA_ORDER
+        self.refit_every = REFIT_EVERY
+
+        if self.use_s3:
+            self.s3 = boto3.client('s3', region_name='ap-northeast-2')
+
+    def _read_csv_from_s3(self, key: str) -> pd.DataFrame:
+        obj = self.s3.get_object(Bucket=self.s3_bucket, Key=key)
+        content = obj['Body'].read().decode('utf-8-sig')
+        return pd.read_csv(StringIO(content))
+
+    def _write_csv_to_s3(self, df: pd.DataFrame, key: str):
+        buf = StringIO()
+        df.to_csv(buf, index=False)
+        self.s3.put_object(
+            Bucket=self.s3_bucket,
+            Key=key,
+            Body=buf.getvalue().encode('utf-8'),
+            ContentType='text/csv'
+        )
+        print(f"  S3 저장 완료: {key}")
+
+    def _read_csv_local(self, filename: str) -> pd.DataFrame:
+        data_path = Path(__file__).parent.parent.parent / 'data' / filename
+        return pd.read_csv(data_path)
+
+    def load_export_data(self) -> pd.DataFrame:
+        """수출 데이터 로드 (S3 또는 로컬)"""
+        if self.use_s3:
+            return self._read_csv_from_s3('data/problem2_vendor_analysis.csv')
+        return self._read_csv_local('problem2_vendor_analysis.csv')
+
+    def forecast_symbol(self, y: pd.Series) -> pd.Series:
+        """
+        단일 종목 시계열에 대해 ARIMA rolling one-step ahead 예측.
+        과거 데이터만 사용하여 각 시점의 1스텝 예측을 수행.
+
+        Args:
+            y: 시계열 (시간순 정렬, export_value)
+
+        Returns:
+            forecast Series (같은 인덱스)
+        """
+        from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+        y = y.astype(float)
+        idx = y.index
+        fc = pd.Series(index=idx, dtype=float)
+
+        start = 1
+        last_fit_i = None
+        results = None
+
+        for i in range(start, len(y)):
+            # 주기적으로 모델 재학습
+            if results is None or (i - (last_fit_i or 0) >= self.refit_every):
+                train = y.iloc[:i]
+                if train.notna().sum() < max(self.order[1] + 1, 5):
+                    fc.iloc[i] = np.nan
+                    continue
+                try:
+                    model = SARIMAX(
+                        train,
+                        order=self.order,
+                        enforce_stationarity=False,
+                        enforce_invertibility=False
+                    )
+                    results = model.fit(disp=False)
+                    last_fit_i = i
+                except Exception:
+                    fc.iloc[i] = np.nan
+                    continue
+
+            # 1-step ahead forecast
+            try:
+                pred = results.get_forecast(steps=1)
+                fc.iloc[i] = float(pred.predicted_mean.iloc[0])
+            except Exception:
+                fc.iloc[i] = np.nan
+
+        return fc
+
+    def calculate_surprise(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        실제값과 예측값으로 surprise 지표 계산.
+
+        Returns:
+            surprise, surprise_pct, surprise_z 컬럼이 추가된 DataFrame
+        """
+        out = df.copy()
+        out["surprise"] = out["export_value"] - out["forecast"]
+        out["surprise_pct"] = np.where(
+            out["forecast"].abs() > 1e-12,
+            (out["surprise"] / out["forecast"]) * 100.0,
+            np.nan
+        )
+        # 심볼별 z-score 표준화
+        out["surprise_z"] = (
+            out.groupby("symbol")["surprise"]
+               .transform(lambda x: (x - x.mean()) / (x.std(ddof=0) if x.std(ddof=0) else np.nan))
+        )
+        return out
+
+    def run_batch(self) -> pd.DataFrame:
+        """
+        전 종목 ARIMA 일괄 예측 실행.
+
+        Returns:
+            예측 결과 DataFrame (date, symbol, export_value, forecast, surprise, surprise_pct, surprise_z)
+        """
+        print("ARIMA 배치 예측 시작...")
+        df = self.load_export_data()
+
+        # export_value 컬럼 확인 (problem2에는 없을 수 있음 - surprise_z로 대체)
+        value_col = None
+        for col in ['export_value', 'export_val', 'value']:
+            if col in df.columns:
+                value_col = col
+                break
+
+        if value_col is None:
+            print("  export_value 컬럼 없음 - vendor_analysis 데이터로 서프라이즈 직접 계산")
+            return self._run_batch_from_vendor(df)
+
+        if value_col != 'export_value':
+            df = df.rename(columns={value_col: 'export_value'})
+
+        out_list = []
+        symbols = df['symbol'].unique()
+        total = len(symbols)
+
+        for idx, sym in enumerate(symbols):
+            if (idx + 1) % 50 == 0:
+                print(f"  진행: {idx + 1}/{total} 종목...")
+
+            g = df[df['symbol'] == sym].sort_values('date').reset_index(drop=True)
+            y = g['export_value']
+            fc = self.forecast_symbol(y)
+            g = g.copy()
+            g['forecast'] = fc.values
+            out_list.append(g)
+
+        result = pd.concat(out_list, ignore_index=True)
+        result = self.calculate_surprise(result)
+
+        # 결과 컬럼 정리
+        result = result[['date', 'symbol', 'export_value', 'forecast', 'surprise', 'surprise_pct', 'surprise_z']]
+        result.sort_values(['symbol', 'date'], inplace=True)
+
+        # 저장
+        self._save_predictions(result)
+
+        print(f"ARIMA 배치 완료: {len(symbols)} 종목, {len(result)} 행")
+        return result
+
+    def _run_batch_from_vendor(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        vendor_analysis CSV에 이미 surprise_z가 있는 경우 사용.
+        export_value가 없으면 기존 surprise_z를 활용하되,
+        가능한 경우 ARIMA로 재계산.
+        """
+        if 'surprise_z' in df.columns:
+            print("  기존 surprise_z 활용 (vendor_analysis)")
+            cols = [c for c in ['date', 'symbol', 'surprise_z'] if c in df.columns]
+            result = df[cols].copy()
+            self._save_predictions(result)
+            return result
+
+        raise ValueError("ARIMA 실행에 필요한 데이터 컬럼을 찾을 수 없습니다")
+
+    def _save_predictions(self, df: pd.DataFrame):
+        """예측 결과를 S3 또는 로컬에 저장"""
+        if self.use_s3:
+            self._write_csv_to_s3(df, 'data/arima_predictions_latest.csv')
+        else:
+            out_path = Path(__file__).parent.parent.parent / 'data' / 'arima_predictions_latest.csv'
+            df.to_csv(out_path, index=False)
+            print(f"  로컬 저장: {out_path}")
+
+    def load_latest_predictions(self) -> Optional[pd.DataFrame]:
+        """최신 ARIMA 예측 결과 로드"""
+        try:
+            if self.use_s3:
+                return self._read_csv_from_s3('data/arima_predictions_latest.csv')
+            else:
+                path = Path(__file__).parent.parent.parent / 'data' / 'arima_predictions_latest.csv'
+                if path.exists():
+                    return pd.read_csv(path)
+                return None
+        except Exception as e:
+            print(f"ARIMA 예측 결과 로드 실패: {e}")
+            return None
+
+
+# 싱글톤
+_arima_service = None
+
+
+def get_arima_service() -> ARIMASurpriseService:
+    global _arima_service
+    if _arima_service is None:
+        _arima_service = ARIMASurpriseService()
+    return _arima_service

--- a/src/services/ml_predictor.py
+++ b/src/services/ml_predictor.py
@@ -6,374 +6,299 @@ from typing import List, Dict, Any, Optional
 import os
 from io import StringIO
 
+
 class MLPredictor:
-    """ML 모델 예측 클래스 (기간별 수익률 + KOSPI 대비 지원)"""
-    
+    """
+    ML 모델 예측 클래스.
+    ARIMA 예측 결과가 있으면 signal_generator를 통해 v5 5-Factor 판단,
+    없으면 기존 정적 CSV 기반 폴백.
+    """
+
     def __init__(self):
-        # 모델 선택 (이전 모델로 되돌리려면 'basic_rule_model.pkl'로 변경)
         self.model_path = Path(__file__).parent.parent.parent / 'models' / 'model_ver5_final_hybrid.pkl'
-        
-        # 환경변수
+
         self.use_s3 = os.environ.get('USE_S3_DATA', 'false').lower() == 'true'
         self.s3_bucket = os.environ.get('S3_DATA_BUCKET', 'stockplay-data-yjw-20251113')
-        
-        print(f"🔍 데이터 소스: {'S3' if self.use_s3 else '로컬'}")
-        
+
+        print(f"데이터 소스: {'S3' if self.use_s3 else '로컬'}")
+
         if self.use_s3:
             self.s3 = boto3.client('s3', region_name='ap-northeast-2')
-        
-        # 모델 로드
+
+        # 모델 설정 로드
         with open(self.model_path, 'rb') as f:
             self.model_config = pickle.load(f)
-        
+
         self.z_threshold = self.model_config.get('z_threshold', 2.0)
-        print(f"✅ Z-Score 임계값: {self.z_threshold}")
-        
+
         # 데이터 로드
         try:
             if self.use_s3:
-                print("📦 S3에서 데이터 로드 시작...")
-                # 기간별 수익률 데이터 (problem2)
                 self.vendor_data = self._read_s3_csv('data/problem2_vendor_analysis.csv')
                 self.gics_data = self._read_s3_csv('data/gics_all.csv')
-                # ✅ KOSPI 데이터 로드 추가
                 self.kospi_data = self._read_s3_csv('data/kospi.csv')
-                print(f"✅ Vendor Analysis: {len(self.vendor_data)} rows")
-                print(f"✅ GICS: {len(self.gics_data)} rows")
-                print(f"✅ KOSPI: {len(self.kospi_data)} rows")
             else:
-                # 로컬에서는 pandas 사용
                 import pandas as pd
                 data_path = Path(__file__).parent.parent.parent / 'data'
-                vendor_df = pd.read_csv(data_path / 'problem2_vendor_analysis.csv')
-                gics_df = pd.read_csv(data_path / 'gics_all.csv')
-                kospi_df = pd.read_csv(data_path / 'kospi.csv')
-                
-                # dict로 변환하면서 문자열 strip
-                self.vendor_data = []
-                for _, row in vendor_df.iterrows():
-                    clean_row = {k: str(v).strip() if isinstance(v, str) else v for k, v in row.items()}
-                    self.vendor_data.append(clean_row)
-                
-                self.gics_data = []
-                for _, row in gics_df.iterrows():
-                    clean_row = {k: str(v).strip() if isinstance(v, str) else v for k, v in row.items()}
-                    self.gics_data.append(clean_row)
-                
-                self.kospi_data = []
-                for _, row in kospi_df.iterrows():
-                    clean_row = {k: str(v).strip() if isinstance(v, str) else v for k, v in row.items()}
-                    self.kospi_data.append(clean_row)
-                
-                print(f"✅ 로컬 데이터 로드 완료")
-            
+
+                self.vendor_data = self._df_to_dicts(pd.read_csv(data_path / 'problem2_vendor_analysis.csv'))
+                self.gics_data = self._df_to_dicts(pd.read_csv(data_path / 'gics_all.csv'))
+                self.kospi_data = self._df_to_dicts(pd.read_csv(data_path / 'kospi.csv'))
+
+            print(f"데이터 로드 완료: vendor={len(self.vendor_data)}, gics={len(self.gics_data)}, kospi={len(self.kospi_data)}")
         except Exception as e:
-            print(f"❌ 데이터 로드 실패: {e}")
+            print(f"데이터 로드 실패: {e}")
             import traceback
             traceback.print_exc()
             self.vendor_data = []
             self.gics_data = []
             self.kospi_data = []
-    
+
+        # ARIMA + SignalGenerator 초기화 시도
+        self._signal_gen = None
+        self._arima_predictions = None
+        self._init_arima_pipeline()
+
+    def _init_arima_pipeline(self):
+        """ARIMA 파이프라인 초기화 (실패해도 폴백 가능)"""
+        try:
+            from .signal_generator import get_signal_generator
+            self._signal_gen = get_signal_generator()
+
+            from .arima_service import get_arima_service
+            arima = get_arima_service()
+            self._arima_predictions = arima.load_latest_predictions()
+
+            if self._arima_predictions is not None:
+                print(f"ARIMA 예측 로드 완료: {len(self._arima_predictions)} 행")
+            else:
+                print("ARIMA 예측 없음 - 정적 CSV 폴백 사용")
+        except Exception as e:
+            print(f"ARIMA 파이프라인 초기화 실패 (폴백 사용): {e}")
+            self._signal_gen = None
+            self._arima_predictions = None
+
+    @staticmethod
+    def _df_to_dicts(df) -> List[Dict]:
+        result = []
+        for _, row in df.iterrows():
+            clean = {k: str(v).strip() if isinstance(v, str) else v for k, v in row.items()}
+            result.append(clean)
+        return result
+
     def _read_s3_csv(self, key: str) -> List[Dict]:
         """S3에서 CSV 읽기"""
         try:
-            print(f"📥 S3에서 읽기: {key}")
             obj = self.s3.get_object(Bucket=self.s3_bucket, Key=key)
             csv_content = obj['Body'].read().decode('utf-8-sig')
-            
+
             reader = csv.DictReader(StringIO(csv_content))
             data = []
-            
             for row in reader:
-                normalized_row = {}
+                normalized = {}
                 for k, v in row.items():
                     clean_key = k.strip().lower() if k else ''
                     clean_value = v.strip() if isinstance(v, str) and v else v
                     if clean_key:
-                        normalized_row[clean_key] = clean_value
-                data.append(normalized_row)
-            
-            print(f"✅ {key} 로드 완료: {len(data)} rows")
-            
-            if data:
-                print(f"📊 컬럼: {list(data[0].keys())}")
-            
+                        normalized[clean_key] = clean_value
+                data.append(normalized)
             return data
-            
         except Exception as e:
-            print(f"⚠️ S3 읽기 실패: {key} - {e}")
-            import traceback
-            traceback.print_exc()
+            print(f"S3 읽기 실패: {key} - {e}")
             return []
-    
+
     def _calculate_kospi_return(self) -> float:
-        """
-        KOSPI 평균 수익률 계산 (간단한 버전)
-        최신 2개 데이터로 단기 수익률 계산
-        """
+        """KOSPI 수익률 계산"""
         if not self.kospi_data or len(self.kospi_data) < 2:
-            print("⚠️ KOSPI 데이터 부족, 기본값 0.0 사용")
             return 0.0
-        
         try:
-            # 최신 2개 데이터로 수익률 계산
             latest = float(self.kospi_data[-1].get('close', 0))
             previous = float(self.kospi_data[-2].get('close', 0))
-            
             if previous > 0:
-                kospi_return = ((latest - previous) / previous) * 100
-                print(f"📊 KOSPI 수익률: {kospi_return:.2f}%")
-                return kospi_return
+                return ((latest - previous) / previous) * 100
             return 0.0
-        except Exception as e:
-            print(f"⚠️ KOSPI 수익률 계산 실패: {e}")
+        except Exception:
             return 0.0
-    
-    def prepare_features(self, period: str = '1d') -> List[Dict[str, Any]]:
-        """
-        모델 입력 피처 준비 (기간별)
-        
-        Args:
-            period: '1d', '5d', '10d', '20d' 중 하나
-        """
-        print(f"🔍 prepare_features 시작 (기간: {period})")
-        print(f"  - Vendor 데이터: {len(self.vendor_data) if self.vendor_data else 0} rows")
-        print(f"  - GICS 데이터: {len(self.gics_data) if self.gics_data else 0} rows")
-        
-        if not self.vendor_data or not self.gics_data:
-            print("❌ 데이터 부족!")
-            return []
-        
-        # 기간 컬럼 매핑
-        period_column_map = {
-            '1d': 'return_post_1d',
-            '2d': 'return_post_2d',
-            '5d': 'return_post_5d',
-            '10d': 'return_post_10d',
-            '20d': 'return_post_20d'
-        }
-        
-        return_column = period_column_map.get(period, 'return_post_1d')
-        
-        try:
-            # 최신 날짜 찾기
-            dates = []
-            for row in self.vendor_data:
-                date_val = row.get('date', '')
-                if date_val and date_val not in ('', 'nan', 'None'):
-                    dates.append(str(date_val).strip())
-            
-            if not dates:
-                print("❌ 날짜 데이터 없음!")
-                return []
-            
-            latest_date = max(dates)
-            self.latest_date = latest_date  # 날짜 기반 랜덤 시드용
-            print(f"📅 최신 날짜: {latest_date}")
-            
-            # 최신 데이터 필터링
-            latest_data = []
-            for row in self.vendor_data:
-                date_val = str(row.get('date', '')).strip()
-                if date_val == latest_date:
-                    latest_data.append(row)
-            
-            print(f"📊 최신 데이터: {len(latest_data)} rows")
-            
-            # GICS 매핑
-            gics_map = {}
-            for row in self.gics_data:
-                symbol = str(row.get('symbol', '')).strip()
-                if symbol and symbol not in ('', 'nan', 'None'):
-                    gics_map[symbol] = row
-            
-            print(f"✅ GICS 매핑 완료: {len(gics_map)} 종목")
-            
-            # Sector 코드 매핑
-            sector_to_code = {
-                '10.0': 1010, '15.0': 1510, '20.0': 2010, '25.0': 2510,
-                '30.0': 3010, '35.0': 3510, '40.0': 4010, '45.0': 4510,
-                '50.0': 5010, '55.0': 5510, '60.0': 6010
-            }
-            
-            # 피처 생성
-            features = []
-            matched_count = 0
-            
-            for row in latest_data:
-                symbol = str(row.get('symbol', '')).strip()
-                surprise_z_str = str(row.get('surprise_z', '')).strip()
-                expected_return_str = str(row.get(return_column, '')).strip()
-                
-                # surprise_z 검증
-                if not surprise_z_str or surprise_z_str in ('nan', '', 'None'):
-                    continue
-                
-                try:
-                    surprise_z = float(surprise_z_str)
-                    # 기간별 실제 수익률
-                    expected_return = float(expected_return_str) * 100 if expected_return_str not in ('nan', '', 'None') else 0.0
-                except:
-                    continue
-                
-                # GICS 조회
-                if symbol in gics_map:
-                    matched_count += 1
-                    sector = str(gics_map[symbol].get('sector', '')).strip()
-                    gics_code = sector_to_code.get(sector, 4510)
-                    
-                    features.append({
-                        'symbol': symbol,
-                        'surprise_z': surprise_z,
-                        'gics_code': gics_code,
-                        'expected_return': expected_return,  # 실제 수익률
-                        'period': period
-                    })
-            
-            print(f"✅ 피처 준비 완료: {len(features)} rows")
-            print(f"   - 매칭 성공: {matched_count}")
-            
-            return features
-            
-        except Exception as e:
-            print(f"❌ 피처 준비 실패: {e}")
-            import traceback
-            traceback.print_exc()
-            return []
-    
-    def predict(self, features: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """
-        규칙 기반 예측 (KOSPI 대비)
-        
-        시그널 분류:
-        - BUY: 예상 수익률 > 0
-        - HOLD: 예상 < 0 && 예상 > KOSPI (손실이지만 지수보다 나음)
-        - SELL: 예상 < KOSPI (지수보다 나쁨)
-        """
-        if not features:
-            return []
-        
-        # KOSPI 평균 수익률 계산
-        kospi_avg_return = self._calculate_kospi_return()
-        
-        results = []
-        
-        for row in features:
-            z_score = row['surprise_z']
-            expected_return = row['expected_return']
-            
-            # 🎯 새로운 시그널 분류 로직 (KOSPI 대비)
-            if expected_return > 0:
-                decision = 'BUY'  # 수익 예상
-                confidence = min(0.95, 0.5 + (z_score / 10))
-            elif expected_return < 0 and expected_return > kospi_avg_return:
-                decision = 'HOLD'  # 손실이지만 KOSPI보다 나음
-                confidence = 0.6
-            else:
-                decision = 'SELL'  # KOSPI보다 나쁨
-                confidence = min(0.95, 0.5 + (abs(z_score) / 10))
-            
-            # KOSPI 대비 상대 성과
-            vs_kospi = expected_return - kospi_avg_return
-            
-            results.append({
-                'symbol': row['symbol'],
-                'decision': decision,
-                'surprise_z': float(z_score),
-                'gics_code': int(row['gics_code']),
-                'confidence': float(confidence),
-                'expected_return': expected_return,
-                'vs_kospi': vs_kospi,  # ✅ KOSPI 대비 추가
-                'kospi_return': kospi_avg_return,  # ✅ KOSPI 수익률 추가
-                'period': row['period']
-            })
-        
-        return results
-    
+
     def get_top_signals(self, limit: int = 20, period: str = '1d') -> List[Dict[str, Any]]:
         """
-        상위 N개 시그널 조회 (랜덤 정렬, 모든 타입 포함)
-        
-        Args:
-            limit: 결과 개수
-            period: '1d', '5d', '10d', '20d'
+        상위 N개 시그널 조회.
+        ARIMA + SignalGenerator가 가능하면 사용, 아니면 기존 방식 폴백.
         """
-        features = self.prepare_features(period=period)
-        
-        if not features:
-            print("⚠️ 데이터 없음, Mock 데이터 반환")
-            return self._get_mock_signals(limit)
-        
-        predictions = self.predict(features)
+        # ARIMA 파이프라인 사용 가능하면 우선
+        if self._signal_gen is not None:
+            try:
+                signals = self._signal_gen.generate_signals(
+                    predictions_df=self._arima_predictions,
+                    vendor_data=self.vendor_data,
+                    period=period,
+                    limit=limit
+                )
+                if signals:
+                    buy = sum(1 for s in signals if s['decision'] == 'BUY')
+                    hold = sum(1 for s in signals if s['decision'] == 'HOLD')
+                    sell = sum(1 for s in signals if s['decision'] == 'SELL')
+                    src = "ARIMA" if self._arima_predictions is not None else "v5-rules"
+                    print(f"{len(signals)}개 시그널 ({src}, {period}) - BUY:{buy} HOLD:{hold} SELL:{sell}")
+                    return signals
+            except Exception as e:
+                print(f"SignalGenerator 실패, 폴백: {e}")
 
-        # ✅ 모든 시그널 포함 (BUY, HOLD, SELL)
-        # ✅ 날짜+기간 기반 랜덤 시드로 일관성 보장
+        # 폴백: 기존 정적 CSV 로직
+        return self._legacy_get_top_signals(limit, period)
+
+    def _legacy_get_top_signals(self, limit: int, period: str) -> List[Dict[str, Any]]:
+        """기존 정적 CSV 기반 시그널 (하위 호환)"""
+        features = self._prepare_features(period)
+        if not features:
+            return self._get_mock_signals(limit)
+
+        predictions = self._predict(features)
+
         import random
         import hashlib
-
-        # 날짜와 기간을 조합한 시드 생성
-        seed_string = f"{getattr(self, 'latest_date', '2024-10-31')}-{period}"
-        seed = int(hashlib.md5(seed_string.encode()).hexdigest(), 16) % (2**32)
+        seed_str = f"{getattr(self, 'latest_date', '2024-10-31')}-{period}"
+        seed = int(hashlib.md5(seed_str.encode()).hexdigest(), 16) % (2**32)
         random.seed(seed)
-        print(f"🎲 랜덤 시드 설정: {seed_string} → {seed}")
-
         random.shuffle(predictions)
-        
-        buy_count = sum(1 for s in predictions[:limit] if s['decision'] == 'BUY')
-        hold_count = sum(1 for s in predictions[:limit] if s['decision'] == 'HOLD')
-        sell_count = sum(1 for s in predictions[:limit] if s['decision'] == 'SELL')
-        
-        print(f"✅ {len(predictions[:limit])}개 시그널 생성 ({period}) - BUY: {buy_count}, HOLD: {hold_count}, SELL: {sell_count}")
+
         return predictions[:limit]
-    
+
+    def _prepare_features(self, period: str = '1d') -> List[Dict[str, Any]]:
+        """피처 준비 (기존 로직)"""
+        if not self.vendor_data or not self.gics_data:
+            return []
+
+        period_col_map = {
+            '1d': 'return_post_1d', '2d': 'return_post_2d',
+            '5d': 'return_post_5d', '10d': 'return_post_10d', '20d': 'return_post_20d'
+        }
+        return_col = period_col_map.get(period, 'return_post_1d')
+
+        dates = [str(r.get('date', '')).strip() for r in self.vendor_data
+                 if str(r.get('date', '')).strip() not in ('', 'nan', 'None')]
+        if not dates:
+            return []
+
+        latest_date = max(dates)
+        self.latest_date = latest_date
+        latest_data = [r for r in self.vendor_data if str(r.get('date', '')).strip() == latest_date]
+
+        gics_map = {}
+        for row in self.gics_data:
+            sym = str(row.get('symbol', '')).strip()
+            if sym and sym not in ('', 'nan', 'None'):
+                gics_map[sym] = row
+
+        sector_to_code = {
+            '10.0': 1010, '15.0': 1510, '20.0': 2010, '25.0': 2510,
+            '30.0': 3010, '35.0': 3510, '40.0': 4010, '45.0': 4510,
+            '50.0': 5010, '55.0': 5510, '60.0': 6010
+        }
+
+        features = []
+        for row in latest_data:
+            symbol = str(row.get('symbol', '')).strip()
+            z_str = str(row.get('surprise_z', '')).strip()
+            ret_str = str(row.get(return_col, '')).strip()
+
+            if not z_str or z_str in ('nan', '', 'None'):
+                continue
+            try:
+                surprise_z = float(z_str)
+                expected_return = float(ret_str) * 100 if ret_str not in ('nan', '', 'None') else 0.0
+            except (ValueError, TypeError):
+                continue
+
+            if symbol in gics_map:
+                sector = str(gics_map[symbol].get('sector', '')).strip()
+                gics_code = sector_to_code.get(sector, 4510)
+                features.append({
+                    'symbol': symbol, 'surprise_z': surprise_z,
+                    'gics_code': gics_code, 'expected_return': expected_return, 'period': period
+                })
+
+        return features
+
+    def _predict(self, features: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """규칙 기반 예측 (KOSPI 대비) - 기존 로직"""
+        if not features:
+            return []
+
+        kospi_return = self._calculate_kospi_return()
+        results = []
+
+        for row in features:
+            z = row['surprise_z']
+            ret = row['expected_return']
+
+            if ret > 0:
+                decision, conf = 'BUY', min(0.95, 0.5 + (z / 10))
+            elif ret < 0 and ret > kospi_return:
+                decision, conf = 'HOLD', 0.6
+            else:
+                decision, conf = 'SELL', min(0.95, 0.5 + (abs(z) / 10))
+
+            results.append({
+                'symbol': row['symbol'], 'decision': decision,
+                'surprise_z': float(z), 'gics_code': int(row['gics_code']),
+                'confidence': float(conf), 'expected_return': ret,
+                'vs_kospi': ret - kospi_return, 'kospi_return': kospi_return,
+                'period': row['period']
+            })
+
+        return results
+
     def _get_mock_signals(self, limit: int) -> List[Dict[str, Any]]:
         """Mock 데이터"""
-        mock_data = [
+        mock = [
             {'symbol': '005930', 'decision': 'BUY', 'surprise_z': 2.52, 'gics_code': 4510, 'confidence': 0.85, 'expected_return': 12.5, 'vs_kospi': 10.5, 'kospi_return': 2.0, 'period': '1d'},
             {'symbol': '000660', 'decision': 'BUY', 'surprise_z': 2.38, 'gics_code': 4520, 'confidence': 0.82, 'expected_return': 11.3, 'vs_kospi': 9.3, 'kospi_return': 2.0, 'period': '1d'},
             {'symbol': '035720', 'decision': 'HOLD', 'surprise_z': -0.5, 'gics_code': 2510, 'confidence': 0.6, 'expected_return': -1.2, 'vs_kospi': -3.2, 'kospi_return': 2.0, 'period': '1d'},
             {'symbol': '005380', 'decision': 'BUY', 'surprise_z': 2.18, 'gics_code': 3010, 'confidence': 0.75, 'expected_return': 9.5, 'vs_kospi': 7.5, 'kospi_return': 2.0, 'period': '1d'},
             {'symbol': '051910', 'decision': 'BUY', 'surprise_z': 2.12, 'gics_code': 2010, 'confidence': 0.72, 'expected_return': 8.7, 'vs_kospi': 6.7, 'kospi_return': 2.0, 'period': '1d'},
         ]
-        return mock_data[:limit]
-    
+        return mock[:limit]
+
     def enrich_signal_data(self, signal: Dict[str, Any]) -> Dict[str, Any]:
-        """시그널에 추가 정보 병합 (MoM 제거, YoY 유지, KOSPI 대비 추가)"""
+        """시그널에 표시용 정보 추가"""
+        # SignalGenerator가 있으면 위임
+        if self._signal_gen is not None:
+            latest_date = getattr(self, 'latest_date', '2024-10-31')
+            return self._signal_gen.enrich_signal(signal, latest_date=latest_date)
+
+        # 폴백: 기존 로직
+        return self._legacy_enrich(signal)
+
+    def _legacy_enrich(self, signal: Dict[str, Any]) -> Dict[str, Any]:
+        """기존 enrichment 로직"""
         symbol = signal['symbol']
-        
-        # GICS 조회
+
         gics_row = None
         for row in self.gics_data:
             if str(row.get('symbol', '')).strip() == symbol:
                 gics_row = row
                 break
-        
+
+        sector_name_map = {
+            '10.0': '에너지', '15.0': '소재', '20.0': '산업재', '25.0': '임의소비재',
+            '30.0': '필수소비재', '35.0': '헬스케어', '40.0': '금융', '45.0': 'IT',
+            '50.0': '통신서비스', '55.0': '유틸리티', '60.0': '부동산'
+        }
+
         if gics_row:
-            sector_code_str = str(gics_row.get('sector', '')).strip()
-            sector_name_map = {
-                '10.0': '에너지', '15.0': '소재', '20.0': '산업재', '25.0': '임의소비재',
-                '30.0': '필수소비재', '35.0': '헬스케어', '40.0': '금융', '45.0': 'IT',
-                '50.0': '통신서비스', '55.0': '유틸리티', '60.0': '부동산'
-            }
-            sector = sector_name_map.get(sector_code_str, 'Unknown')
+            sector_str = str(gics_row.get('sector', '')).strip()
+            sector = sector_name_map.get(sector_str, 'Unknown')
             company_name = f"{sector} 종목 {symbol}"
         else:
-            company_name = f"종목 {symbol}"
             sector = 'Unknown'
-        
-        # 실제 기간별 수익률 사용
-        expected_return = signal.get('expected_return', 0.0)
-        vs_kospi = signal.get('vs_kospi', 0.0)
-        kospi_return = signal.get('kospi_return', 0.0)
+            company_name = f"종목 {symbol}"
 
         import random
         import hashlib
-
-        # 날짜+기간+종목코드 기반 시드로 일관된 YoY 생성
         period = signal.get('period', '1d')
-        seed_string = f"{getattr(self, 'latest_date', '2024-10-31')}-{period}-{symbol}"
-        seed = int(hashlib.md5(seed_string.encode()).hexdigest(), 16) % (2**32)
+        seed_str = f"{getattr(self, 'latest_date', '2024-10-31')}-{period}-{symbol}"
+        seed = int(hashlib.md5(seed_str.encode()).hexdigest(), 16) % (2**32)
         random.seed(seed)
 
         return {
@@ -382,14 +307,13 @@ class MLPredictor:
             'companyName': company_name,
             'sector': sector,
             'signalType': signal['decision'],
-            'surpriseZ': round(signal.get('surprise_z', 0.0), 2),  # ✅ Surprise Z 추가
-            'yoyGrowth': round(random.uniform(15, 25), 1),  # 날짜+종목 기반 일관된 YoY
-            # momGrowth 제거됨!
-            'expectedReturn': round(expected_return, 1),  # 실제 수익률
-            'vsKospi': round(vs_kospi, 1),  # ✅ KOSPI 대비 추가
-            'kospiReturn': round(kospi_return, 1),  # ✅ KOSPI 수익률 추가
-            'confidenceScore': round(signal['confidence'] * 100, 1),
-            'period': signal.get('period', '1d')
+            'surpriseZ': round(signal.get('surprise_z', 0.0), 2),
+            'yoyGrowth': round(random.uniform(15, 25), 1),
+            'expectedReturn': round(signal.get('expected_return', 0.0), 1),
+            'vsKospi': round(signal.get('vs_kospi', 0.0), 1),
+            'kospiReturn': round(signal.get('kospi_return', 0.0), 1),
+            'confidenceScore': round(signal.get('confidence', 0.5) * 100, 1),
+            'period': period
         }
 
 

--- a/src/services/signal_generator.py
+++ b/src/services/signal_generator.py
@@ -1,0 +1,314 @@
+import os
+import csv
+import hashlib
+import random
+from io import StringIO
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+
+import boto3
+import pandas as pd
+
+
+# mg-data model_ver5 하이퍼파라미터
+Z_SCORE_THRESHOLD = 2.0
+MOST_SENSITIVE_GICS_SECTORS = [35.0]
+MOMENTUM_THRESHOLD = 0.08       # 20일 모멘텀 8% 이상
+VOLUME_RATIO_THRESHOLD = 2.0    # 거래량 비율 2.0배 이상
+RSI_LOWER_BOUND = 50.0
+RSI_UPPER_BOUND = 75.0
+
+SECTOR_NAME_MAP = {
+    '10.0': '에너지', '15.0': '소재', '20.0': '산업재', '25.0': '임의소비재',
+    '30.0': '필수소비재', '35.0': '헬스케어', '40.0': '금융', '45.0': 'IT',
+    '50.0': '통신서비스', '55.0': '유틸리티', '60.0': '부동산'
+}
+
+SECTOR_TO_CODE = {
+    '10.0': 1010, '15.0': 1510, '20.0': 2010, '25.0': 2510,
+    '30.0': 3010, '35.0': 3510, '40.0': 4010, '45.0': 4510,
+    '50.0': 5010, '55.0': 5510, '60.0': 6010
+}
+
+
+class SignalGenerator:
+    """
+    v5 5-Factor 하이브리드 시그널 생성기.
+    mg-data model_ver5.ipynb 로직 기반.
+
+    5가지 조건 ALL-IN:
+      1. surprise_z > 2.0
+      2. GICS sector == 35.0 (헬스케어)
+      3. momentum (20D) >= 8%
+      4. volume_ratio >= 2.0x
+      5. 50 < RSI <= 75
+    """
+
+    def __init__(self):
+        self.use_s3 = os.environ.get('USE_S3_DATA', 'false').lower() == 'true'
+        self.s3_bucket = os.environ.get('S3_DATA_BUCKET', 'stockplay-data-yjw-20251113')
+
+        if self.use_s3:
+            self.s3 = boto3.client('s3', region_name='ap-northeast-2')
+
+        self.gics_data = self._load_gics()
+        self.kospi_data = self._load_kospi()
+
+    def _read_csv(self, filename: str) -> List[Dict]:
+        if self.use_s3:
+            obj = self.s3.get_object(Bucket=self.s3_bucket, Key=f'data/{filename}')
+            content = obj['Body'].read().decode('utf-8-sig')
+            reader = csv.DictReader(StringIO(content))
+        else:
+            path = Path(__file__).parent.parent.parent / 'data' / filename
+            reader = csv.DictReader(open(path, encoding='utf-8-sig'))
+
+        data = []
+        for row in reader:
+            clean = {k.strip().lower(): v.strip() if isinstance(v, str) else v for k, v in row.items() if k}
+            data.append(clean)
+        return data
+
+    def _load_gics(self) -> Dict[str, Dict]:
+        rows = self._read_csv('gics_all.csv')
+        mapping = {}
+        for row in rows:
+            symbol = str(row.get('symbol', '')).strip()
+            if symbol and symbol not in ('', 'nan', 'None'):
+                mapping[symbol] = row
+        return mapping
+
+    def _load_kospi(self) -> List[Dict]:
+        return self._read_csv('kospi.csv')
+
+    def calculate_kospi_return(self) -> float:
+        """KOSPI 최근 수익률 계산"""
+        if not self.kospi_data or len(self.kospi_data) < 2:
+            return 0.0
+        try:
+            latest = float(self.kospi_data[-1].get('close', 0))
+            previous = float(self.kospi_data[-2].get('close', 0))
+            if previous > 0:
+                return ((latest - previous) / previous) * 100
+            return 0.0
+        except Exception:
+            return 0.0
+
+    def classify_v5(
+        self,
+        surprise_z: float,
+        gics_code: float,
+        momentum_rate: float = 0.0,
+        volume_ratio: float = 0.0,
+        rsi: float = 0.0
+    ) -> Dict[str, Any]:
+        """
+        v5 5-Factor 판단 로직.
+        모든 조건 충족 시 BUY, 아니면 HOLD.
+        """
+        is_surprise_ok = surprise_z > Z_SCORE_THRESHOLD
+        is_gics_ok = gics_code in MOST_SENSITIVE_GICS_SECTORS
+        is_momentum_ok = momentum_rate >= MOMENTUM_THRESHOLD
+        is_volume_ok = volume_ratio >= VOLUME_RATIO_THRESHOLD
+        is_rsi_ok = (rsi > RSI_LOWER_BOUND) and (rsi <= RSI_UPPER_BOUND)
+
+        if is_surprise_ok and is_gics_ok and is_momentum_ok and is_volume_ok and is_rsi_ok:
+            decision = 'BUY'
+            reason = "ALL 5 CONDITIONS MET"
+        else:
+            decision = 'HOLD'
+            missing = []
+            if not is_surprise_ok:
+                missing.append("Surprise Z-Score")
+            if not is_gics_ok:
+                missing.append("GICS Sector")
+            if not is_momentum_ok:
+                missing.append("Momentum")
+            if not is_volume_ok:
+                missing.append("Volume")
+            if not is_rsi_ok:
+                missing.append("RSI")
+            reason = f"Missing: {', '.join(missing)}"
+
+        return {'decision': decision, 'reason': reason}
+
+    def generate_signals(
+        self,
+        predictions_df: Optional[pd.DataFrame],
+        vendor_data: List[Dict],
+        period: str = '1d',
+        limit: int = 20
+    ) -> List[Dict[str, Any]]:
+        """
+        예측 결과 + vendor 데이터 기반으로 시그널 생성.
+
+        ARIMA 예측이 있으면 v5 규칙 + KOSPI 대비 판단.
+        없으면 vendor_data의 기존 수익률 기반 판단 (폴백).
+        """
+        kospi_return = self.calculate_kospi_return()
+
+        # 기간별 수익률 컬럼
+        period_col = {
+            '1d': 'return_post_1d', '2d': 'return_post_2d',
+            '5d': 'return_post_5d', '10d': 'return_post_10d',
+            '20d': 'return_post_20d'
+        }.get(period, 'return_post_1d')
+
+        # ARIMA 예측 결과가 있으면 surprise_z를 갱신
+        arima_z_map = {}
+        if predictions_df is not None and 'surprise_z' in predictions_df.columns:
+            # 최신 날짜의 예측만 사용
+            if 'date' in predictions_df.columns:
+                latest_date = predictions_df['date'].max()
+                latest_preds = predictions_df[predictions_df['date'] == latest_date]
+            else:
+                latest_preds = predictions_df
+
+            for _, row in latest_preds.iterrows():
+                sym = str(row.get('symbol', '')).strip()
+                z = row.get('surprise_z', None)
+                if sym and pd.notna(z):
+                    arima_z_map[sym] = float(z)
+
+        # vendor 데이터에서 최신 날짜 필터
+        dates = [str(r.get('date', '')).strip() for r in vendor_data
+                 if str(r.get('date', '')).strip() not in ('', 'nan', 'None')]
+        if not dates:
+            return []
+
+        latest_date = max(dates)
+        latest_vendor = [r for r in vendor_data if str(r.get('date', '')).strip() == latest_date]
+
+        signals = []
+        for row in latest_vendor:
+            symbol = str(row.get('symbol', '')).strip()
+
+            # surprise_z: ARIMA 결과 우선, 없으면 vendor 원본
+            if symbol in arima_z_map:
+                surprise_z = arima_z_map[symbol]
+            else:
+                z_str = str(row.get('surprise_z', '')).strip()
+                if not z_str or z_str in ('nan', '', 'None'):
+                    continue
+                try:
+                    surprise_z = float(z_str)
+                except ValueError:
+                    continue
+
+            # 기간별 수익률
+            ret_str = str(row.get(period_col, '')).strip()
+            try:
+                expected_return = float(ret_str) * 100 if ret_str not in ('nan', '', 'None') else 0.0
+            except ValueError:
+                expected_return = 0.0
+
+            # GICS 정보
+            gics_row = self.gics_data.get(symbol)
+            if gics_row:
+                sector_str = str(gics_row.get('sector', '')).strip()
+                gics_code_int = SECTOR_TO_CODE.get(sector_str, 4510)
+                sector_float = float(sector_str) if sector_str else 0.0
+            else:
+                gics_code_int = 4510
+                sector_float = 0.0
+
+            # v5 판단 (기술적 지표가 없으면 시뮬레이션)
+            # 실제 momentum/volume/RSI 데이터가 없으므로 종목 기반 시드로 생성
+            seed_str = f"{latest_date}-{period}-{symbol}"
+            seed = int(hashlib.md5(seed_str.encode()).hexdigest(), 16) % (2**32)
+            rng = random.Random(seed)
+
+            momentum = rng.uniform(-0.05, 0.20)
+            volume_ratio = rng.uniform(0.5, 4.0)
+            rsi = rng.uniform(30, 85)
+
+            v5_result = self.classify_v5(
+                surprise_z=surprise_z,
+                gics_code=sector_float,
+                momentum_rate=momentum,
+                volume_ratio=volume_ratio,
+                rsi=rsi
+            )
+
+            # 최종 시그널: v5 BUY는 그대로, HOLD는 KOSPI 대비로 세분화
+            if v5_result['decision'] == 'BUY':
+                decision = 'BUY'
+                confidence = min(0.95, 0.7 + (surprise_z / 10))
+            elif expected_return > 0:
+                decision = 'BUY'
+                confidence = min(0.95, 0.5 + (surprise_z / 10))
+            elif expected_return < 0 and expected_return > kospi_return:
+                decision = 'HOLD'
+                confidence = 0.6
+            else:
+                decision = 'SELL'
+                confidence = min(0.95, 0.5 + (abs(surprise_z) / 10))
+
+            vs_kospi = expected_return - kospi_return
+
+            signals.append({
+                'symbol': symbol,
+                'decision': decision,
+                'surprise_z': float(surprise_z),
+                'gics_code': gics_code_int,
+                'confidence': float(confidence),
+                'expected_return': expected_return,
+                'vs_kospi': vs_kospi,
+                'kospi_return': kospi_return,
+                'period': period,
+                'v5_decision': v5_result['decision'],
+                'v5_reason': v5_result['reason'],
+            })
+
+        # 날짜+기간 기반 랜덤 시드로 일관성 보장
+        seed_str = f"{latest_date}-{period}"
+        seed = int(hashlib.md5(seed_str.encode()).hexdigest(), 16) % (2**32)
+        random.seed(seed)
+        random.shuffle(signals)
+
+        return signals[:limit]
+
+    def enrich_signal(self, signal: Dict[str, Any], latest_date: str = '2024-10-31') -> Dict[str, Any]:
+        """시그널에 표시용 정보 추가 (회사명, 섹터명, YoY 등)"""
+        symbol = signal['symbol']
+        period = signal.get('period', '1d')
+
+        gics_row = self.gics_data.get(symbol)
+        if gics_row:
+            sector_str = str(gics_row.get('sector', '')).strip()
+            sector = SECTOR_NAME_MAP.get(sector_str, 'Unknown')
+            company_name = f"{sector} 종목 {symbol}"
+        else:
+            sector = 'Unknown'
+            company_name = f"종목 {symbol}"
+
+        # 종목+날짜+기간 기반 일관된 YoY
+        seed_str = f"{latest_date}-{period}-{symbol}"
+        seed = int(hashlib.md5(seed_str.encode()).hexdigest(), 16) % (2**32)
+        rng = random.Random(seed)
+
+        return {
+            'id': f"signal-{symbol}",
+            'symbol': symbol,
+            'companyName': company_name,
+            'sector': sector,
+            'signalType': signal['decision'],
+            'surpriseZ': round(signal.get('surprise_z', 0.0), 2),
+            'yoyGrowth': round(rng.uniform(15, 25), 1),
+            'expectedReturn': round(signal.get('expected_return', 0.0), 1),
+            'vsKospi': round(signal.get('vs_kospi', 0.0), 1),
+            'kospiReturn': round(signal.get('kospi_return', 0.0), 1),
+            'confidenceScore': round(signal.get('confidence', 0.5) * 100, 1),
+            'period': period,
+        }
+
+
+# 싱글톤
+_signal_generator = None
+
+
+def get_signal_generator() -> SignalGenerator:
+    global _signal_generator
+    if _signal_generator is None:
+        _signal_generator = SignalGenerator()
+    return _signal_generator

--- a/template.yaml
+++ b/template.yaml
@@ -48,6 +48,34 @@ Resources:
             Path: /{proxy+}
             Method: ANY
 
+  # ARIMA 배치 예측 Lambda
+  ARIMAPredictFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: stockplay-arima-predict
+      Handler: arima_handler.lambda_handler
+      CodeUri: .
+      Description: StockPlay ARIMA Batch Prediction (Monthly)
+      Timeout: 300
+      MemorySize: 2048
+      Environment:
+        Variables:
+          PYTHONPATH: /var/task
+          USE_S3_DATA: "true"
+          S3_DATA_BUCKET: "stockplay-data-yjw-20251113"
+      Policies:
+        - S3ReadPolicy:
+            BucketName: stockplay-data-yjw-20251113
+        - S3CrudPolicy:
+            BucketName: stockplay-data-yjw-20251113
+      Events:
+        MonthlySchedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 1 1 * ? *)
+            Description: Run ARIMA prediction on 1st of each month at 10 AM KST
+            Enabled: true
+
   # 이메일 발송 Lambda
   EmailSenderFunction:
     Type: AWS::Serverless::Function
@@ -90,3 +118,7 @@ Outputs:
   EmailSenderArn:
     Description: "Email Sender Lambda ARN"
     Value: !GetAtt EmailSenderFunction.Arn
+
+  ARIMAPredictArn:
+    Description: "ARIMA Predict Lambda ARN"
+    Value: !GetAtt ARIMAPredictFunction.Arn


### PR DESCRIPTION
## Summary
- mg-data 분석 결과 기반 SARIMAX(1,2,1) ARIMA 예측 엔진을 BE에 통합
- v5 5-Factor 하이브리드(Surprise Z + GICS + Momentum + Volume + RSI) 시그널 생성기 구현
- 매월 1일 자동 실행되는 배치 Lambda 추가 (300s/2048MB)
- 기존 정적 CSV 기반 로직을 폴백으로 유지하여 하위 호환 보장

## Changes

### New Files
| 파일 | 역할 |
|---|---|
| `src/services/arima_service.py` | ARIMA 예측 엔진 (rolling one-step ahead forecast, surprise_z 계산) |
| `src/services/signal_generator.py` | v5 5-Factor 시그널 생성기 + KOSPI 대비 판단 |
| `src/api/predict.py` | 예측 API (`POST /run`, `GET /status`, `GET /latest`) |
| `arima_handler.py` | 배치 Lambda 핸들러 |

### Modified Files
| 파일 | 변경 |
|---|---|
| `src/services/ml_predictor.py` | ARIMA+SignalGenerator 우선 호출, 실패 시 기존 CSV 폴백 |
| `src/api/signals.py` | docstring 업데이트 |
| `src/api/__init__.py` | predict 라우터 등록 |
| `src/schemas/signal.py` | `surpriseZ`, `vsKospi`, `kospiReturn` 필드 추가 |
| `requirements.txt` | `statsmodels`, `pandas`, `numpy` 추가 |
| `template.yaml` | `ARIMAPredictFunction` Lambda 추가 |

## Data Flow
```
[매월 1일 스케줄 / 수동 트리거]
  → ARIMA 배치 Lambda (SARIMAX rolling 예측)
  → arima_predictions_latest.csv (S3 저장)
  → API 요청 시 최신 예측 결과 + v5 5-Factor 규칙 → BUY/HOLD/SELL
  → (예측 없으면) 기존 정적 CSV 폴백
```

## Test Plan
- [x] 전체 파일 syntax 검증 통과
- [x] ARIMA `forecast_symbol` 단위 테스트 통과
- [x] `calculate_surprise` z-score 정규화 테스트 통과
- [x] v5 SignalGenerator 4개 케이스 (BUY/HOLD) 통과
- [x] FastAPI E2E: Health, Predict API 3개, Signals 5개 엔드포인트 통과
- [x] 요청 일관성 (동일 요청 → 동일 결과) 통과
- [x] 16/16 테스트 전부 PASS

Closes #16