### PR TITLE
feat: 프리미엄 리포트 시각화 고도화

### DIFF
--- a/email_sender.py
+++ b/email_sender.py
@@ -11,7 +11,7 @@ s3 = boto3.client('s3', region_name='ap-northeast-2')
 
 # 환경변수
 DYNAMODB_TABLE = os.environ.get('DYNAMODB_TABLE', 'stockplay-main')
-SES_FROM_EMAIL = os.environ.get('SES_FROM_EMAIL', 'noreply@stockplay.com')
+SES_FROM_EMAIL = os.environ.get('SES_FROM_EMAIL', 'yyyyjw@naver.com')
 S3_REPORT_BUCKET = os.environ.get('S3_REPORT_BUCKET', 'stockplay-reports-yjw-20251113')
 API_URL = os.environ.get('API_URL', 'https://rwcdhytnni.execute-api.ap-northeast-2.amazonaws.com/Prod/api')
 
@@ -91,71 +91,144 @@ def send_email(to_email: str, report_data: Dict[str, Any]) -> bool:
 
 
 def generate_email_html(report_data: Dict[str, Any]) -> str:
-    """HTML 이메일 본문 생성"""
-    
+    """HTML 이메일 본문 생성 (프리미엄 스타일)"""
+
     top_picks = report_data.get('topPicks', [])[:5]
     performance = report_data.get('performance', {})
-    
+
+    # 시그널 분포 계산
+    all_signals = report_data.get('topPicks', [])
+    buy_count = sum(1 for s in all_signals if s.get('signalType') == 'BUY')
+    hold_count = sum(1 for s in all_signals if s.get('signalType') == 'HOLD')
+    sell_count = sum(1 for s in all_signals if s.get('signalType') == 'SELL')
+    total_signals = max(buy_count + hold_count + sell_count, 1)
+    buy_pct = buy_count / total_signals * 100
+    hold_pct = hold_count / total_signals * 100
+    sell_pct = sell_count / total_signals * 100
+
+    # 색상 코딩된 종목 테이블
     picks_html = ""
     for pick in top_picks:
+        signal_type = pick.get('signalType', 'BUY')
+        ret = pick.get('expectedReturn', 0)
+        ret_color = '#10b981' if ret >= 0 else '#ef4444'
+        signal_colors = {'BUY': '#10b981', 'HOLD': '#f59e0b', 'SELL': '#ef4444'}
+        signal_bg = {'BUY': '#ecfdf5', 'HOLD': '#fffbeb', 'SELL': '#fef2f2'}
+        badge_color = signal_colors.get(signal_type, '#6b7280')
+        badge_bg = signal_bg.get(signal_type, '#f3f4f6')
         picks_html += f"""
         <tr>
-            <td style="padding: 10px; border-bottom: 1px solid #eee;">{pick['symbol']}</td>
-            <td style="padding: 10px; border-bottom: 1px solid #eee;">{pick['sector']}</td>
-            <td style="padding: 10px; border-bottom: 1px solid #eee; color: #10b981;">{pick['expectedReturn']}%</td>
-            <td style="padding: 10px; border-bottom: 1px solid #eee;">{pick['confidenceScore']}%</td>
+            <td style="padding: 12px 10px; border-bottom: 1px solid #f0f0f0; font-weight: bold;">{pick.get('symbol', '')}</td>
+            <td style="padding: 12px 10px; border-bottom: 1px solid #f0f0f0; color: #666;">{pick.get('sector', '')}</td>
+            <td style="padding: 12px 10px; border-bottom: 1px solid #f0f0f0;">
+                <span style="background: {badge_bg}; color: {badge_color}; padding: 3px 10px; border-radius: 12px; font-size: 12px; font-weight: bold;">{signal_type}</span>
+            </td>
+            <td style="padding: 12px 10px; border-bottom: 1px solid #f0f0f0; color: {ret_color}; font-weight: bold;">{ret:+.1f}%</td>
+            <td style="padding: 12px 10px; border-bottom: 1px solid #f0f0f0;">{pick.get('confidenceScore', 0):.0f}%</td>
         </tr>
         """
-    
+
+    avg_return = performance.get('avgReturn', 0)
+    win_rate = performance.get('winRate', 0)
+    sharpe = performance.get('sharpeRatio', 0)
+
     html = f"""
     <!DOCTYPE html>
     <html>
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
-    <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px; color: white; text-align: center;">
-            <h1 style="margin: 0;">📊 StockPlay</h1>
-            <p style="margin: 10px 0 0 0;">일일 트레이딩 리포트</p>
+    <body style="font-family: 'Segoe UI', Arial, sans-serif; max-width: 640px; margin: 0 auto; padding: 0; background-color: #f5f5f5;">
+        <!-- Header -->
+        <div style="background: linear-gradient(135deg, #4c6fff 0%, #667eea 50%, #764ba2 100%); padding: 40px 30px; text-align: center;">
+            <h1 style="margin: 0; color: white; font-size: 28px;">StockPlay</h1>
+            <p style="margin: 8px 0 0 0; color: rgba(255,255,255,0.85); font-size: 14px;">Daily Trading Report - {datetime.now().strftime('%Y.%m.%d')}</p>
         </div>
-        
-        <div style="margin-top: 30px;">
-            <h2 style="color: #333;">🎯 오늘의 Top 5 추천 종목</h2>
-            <table style="width: 100%; border-collapse: collapse;">
+
+        <div style="background: white; padding: 30px;">
+            <!-- Performance Cards -->
+            <table style="width: 100%; border-collapse: collapse; margin-bottom: 30px;">
+                <tr>
+                    <td style="width: 33%; text-align: center; padding: 20px 10px; background: #f8f9ff; border-radius: 8px 0 0 8px;">
+                        <div style="font-size: 24px; font-weight: bold; color: {'#10b981' if avg_return >= 0 else '#ef4444'};">{avg_return:+.1f}%</div>
+                        <div style="font-size: 12px; color: #888; margin-top: 4px;">Avg Return</div>
+                    </td>
+                    <td style="width: 33%; text-align: center; padding: 20px 10px; background: #f8f9ff; border-left: 1px solid #e8e8e8; border-right: 1px solid #e8e8e8;">
+                        <div style="font-size: 24px; font-weight: bold; color: #4c6fff;">{win_rate:.0f}%</div>
+                        <div style="font-size: 12px; color: #888; margin-top: 4px;">Win Rate</div>
+                    </td>
+                    <td style="width: 33%; text-align: center; padding: 20px 10px; background: #f8f9ff; border-radius: 0 8px 8px 0;">
+                        <div style="font-size: 24px; font-weight: bold; color: #4c6fff;">{sharpe:.2f}</div>
+                        <div style="font-size: 12px; color: #888; margin-top: 4px;">Sharpe Ratio</div>
+                    </td>
+                </tr>
+            </table>
+
+            <!-- Signal Distribution Bar -->
+            <div style="margin-bottom: 30px;">
+                <h3 style="color: #333; font-size: 14px; margin-bottom: 10px;">Signal Distribution</h3>
+                <div style="display: flex; height: 28px; border-radius: 14px; overflow: hidden; background: #f0f0f0;">
+                    <div style="width: {buy_pct:.0f}%; background: #10b981; display: flex; align-items: center; justify-content: center;">
+                        <span style="color: white; font-size: 11px; font-weight: bold;">{'BUY ' + str(buy_count) if buy_pct > 15 else ''}</span>
+                    </div>
+                    <div style="width: {hold_pct:.0f}%; background: #f59e0b; display: flex; align-items: center; justify-content: center;">
+                        <span style="color: white; font-size: 11px; font-weight: bold;">{'HOLD ' + str(hold_count) if hold_pct > 15 else ''}</span>
+                    </div>
+                    <div style="width: {sell_pct:.0f}%; background: #ef4444; display: flex; align-items: center; justify-content: center;">
+                        <span style="color: white; font-size: 11px; font-weight: bold;">{'SELL ' + str(sell_count) if sell_pct > 15 else ''}</span>
+                    </div>
+                </div>
+                <div style="display: flex; justify-content: space-between; margin-top: 6px; font-size: 11px; color: #888;">
+                    <span>BUY {buy_count} ({buy_pct:.0f}%)</span>
+                    <span>HOLD {hold_count} ({hold_pct:.0f}%)</span>
+                    <span>SELL {sell_count} ({sell_pct:.0f}%)</span>
+                </div>
+            </div>
+
+            <!-- Top 5 Picks Table -->
+            <h2 style="color: #333; font-size: 16px; margin-bottom: 15px;">Top 5 Picks</h2>
+            <table style="width: 100%; border-collapse: collapse; margin-bottom: 30px;">
                 <thead>
-                    <tr style="background-color: #f8f9fa;">
-                        <th style="padding: 10px; text-align: left;">종목</th>
-                        <th style="padding: 10px; text-align: left;">섹터</th>
-                        <th style="padding: 10px; text-align: left;">예상수익률</th>
-                        <th style="padding: 10px; text-align: left;">신뢰도</th>
+                    <tr style="background-color: #4c6fff;">
+                        <th style="padding: 12px 10px; text-align: left; color: white; font-size: 12px;">Symbol</th>
+                        <th style="padding: 12px 10px; text-align: left; color: white; font-size: 12px;">Sector</th>
+                        <th style="padding: 12px 10px; text-align: left; color: white; font-size: 12px;">Signal</th>
+                        <th style="padding: 12px 10px; text-align: left; color: white; font-size: 12px;">Return</th>
+                        <th style="padding: 12px 10px; text-align: left; color: white; font-size: 12px;">Conf.</th>
                     </tr>
                 </thead>
                 <tbody>
                     {picks_html}
                 </tbody>
             </table>
+
+            <!-- CTA Button -->
+            <div style="text-align: center; margin: 30px 0;">
+                <a href="https://dj4zhs98x0113.cloudfront.net/reports" style="display: inline-block; background: linear-gradient(135deg, #4c6fff, #667eea); color: white; padding: 14px 40px; border-radius: 8px; text-decoration: none; font-weight: bold; font-size: 14px;">
+                    View Full Report
+                </a>
+            </div>
         </div>
-        
-        <div style="margin-top: 30px; padding: 20px; background-color: #f8f9fa; border-radius: 10px;">
-            <h3 style="margin-top: 0; color: #333;">📈 성과 지표</h3>
-            <p><strong>평균 수익률:</strong> {performance.get('avgReturn', 0)}%</p>
-            <p><strong>승률:</strong> {performance.get('winRate', 0)}%</p>
-            <p><strong>Sharpe Ratio:</strong> {performance.get('sharpeRatio', 0)}</p>
-        </div>
-        
-        <div style="margin-top: 30px; padding: 20px; background-color: #fff3cd; border-radius: 10px; border-left: 4px solid #ffc107;">
-            <p style="margin: 0; color: #856404;">
-                ⚠️ 본 리포트는 투자 참고용이며, 투자 판단의 책임은 투자자 본인에게 있습니다.
+
+        <!-- Disclaimer -->
+        <div style="padding: 20px 30px; background-color: #fff8e1; border-top: 3px solid #ffc107;">
+            <p style="margin: 0; color: #856404; font-size: 12px;">
+                ⚠️ This report is for reference only. Investment decisions and outcomes are the sole responsibility of the investor.
             </p>
         </div>
-        
-        <div style="margin-top: 30px; text-align: center; color: #999; font-size: 12px;">
-            <p>© 2025 StockPlay. All rights reserved.</p>
+
+        <!-- Footer -->
+        <div style="padding: 20px; text-align: center; color: #999; font-size: 11px;">
+            <p style="margin: 0;">© 2025 StockPlay. All rights reserved.</p>
+            <p style="margin: 5px 0 0 0;">
+                <a href="https://dj4zhs98x0113.cloudfront.net/subscribe" style="color: #4c6fff; text-decoration: none;">Manage Subscription</a>
+            </p>
         </div>
     </body>
     </html>
     """
-    
+
     return html
 
 

--- a/src/api/subscribe.py
+++ b/src/api/subscribe.py
@@ -23,13 +23,16 @@ async def subscribe(request: SubscribeRequest):
             # 신규 구독 성공 - 환영 이메일 전송
             data = result['data']
 
-            # 환영 이메일 전송 (비동기로 실패해도 구독은 성공)
+            # 환영 이메일 전송 (실패해도 구독은 성공)
+            email_sent = False
             try:
                 from ..services.email_service import get_email_service
                 email_service = get_email_service()
-                email_service.send_welcome_email(request.email)
+                email_sent = email_service.send_welcome_email(request.email)
             except Exception as email_error:
                 print(f"⚠️ 환영 이메일 전송 실패 (구독은 성공): {email_error}")
+                import traceback
+                traceback.print_exc()
 
             response_data = SubscriptionResponse(
                 email=data['email'],
@@ -37,7 +40,8 @@ async def subscribe(request: SubscribeRequest):
                 created_at=data['created_at'],
                 updated_at=data['updated_at'],
                 is_new_subscriber=True,
-                message="구독이 완료되었습니다! 환영 이메일을 확인해주세요."
+                email_sent=email_sent,
+                message="구독이 완료되었습니다! 환영 이메일을 확인해주세요." if email_sent else "구독이 완료되었습니다! (환영 이메일 전송에 실패했습니다)"
             )
             return ApiResponse(success=True, data=response_data)
         else:

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     # AWS 설정
     AWS_REGION: str = "ap-northeast-2"
     S3_BUCKET_NAME: str = "stockplay-reports-yjw-20251113"
+    SES_FROM_EMAIL: str = "yyyyjw@naver.com"
     
     class Config:
         env_file = ".env"

--- a/src/schemas/subscribe.py
+++ b/src/schemas/subscribe.py
@@ -13,6 +13,7 @@ class SubscriptionResponse(BaseModel):
     updated_at: str
     is_new_subscriber: Optional[bool] = None  # 신규 구독자 여부
     message: Optional[str] = None  # 응답 메시지
+    email_sent: Optional[bool] = None  # 환영 이메일 전송 성공 여부
 
 class ToggleNotificationRequest(BaseModel):
     """알림 설정 토글 요청"""

--- a/src/services/chart_generator.py
+++ b/src/services/chart_generator.py
@@ -473,3 +473,221 @@ def generate_kospi_advanced_chart(signal_data: Dict[str, Any], days: int = 60) -
         traceback.print_exc()
         plt.close(fig)
         raise
+
+
+def generate_signal_distribution_chart(signals: List[Dict[str, Any]]) -> bytes:
+    """
+    시그널 분포 도넛 차트 생성
+
+    Args:
+        signals: 시그널 리스트 (각각 signalType 포함)
+
+    Returns:
+        PNG 이미지 바이트
+    """
+    fig, ax = plt.subplots(figsize=(6, 6), facecolor='#1a1f3a')
+
+    # 시그널 타입별 카운트
+    buy_count = sum(1 for s in signals if s.get('signalType') == 'BUY')
+    hold_count = sum(1 for s in signals if s.get('signalType') == 'HOLD')
+    sell_count = sum(1 for s in signals if s.get('signalType') == 'SELL')
+
+    counts = [buy_count, hold_count, sell_count]
+    labels = ['BUY', 'HOLD', 'SELL']
+    chart_colors = ['#10b981', '#f59e0b', '#ef4444']
+
+    # 0인 항목 제거
+    filtered = [(c, l, col) for c, l, col in zip(counts, labels, chart_colors) if c > 0]
+    if not filtered:
+        filtered = [(1, 'No Data', '#9aa0a6')]
+
+    counts_f, labels_f, colors_f = zip(*filtered)
+
+    wedges, texts, autotexts = ax.pie(
+        counts_f,
+        labels=labels_f,
+        colors=colors_f,
+        autopct='%1.0f%%',
+        startangle=90,
+        pctdistance=0.75,
+        wedgeprops=dict(width=0.4, edgecolor='#1a1f3a', linewidth=2)
+    )
+
+    for text in texts:
+        text.set_color('#e5e7eb')
+        text.set_fontsize(12)
+        text.set_fontweight('bold')
+    for autotext in autotexts:
+        autotext.set_color('#e5e7eb')
+        autotext.set_fontsize(11)
+
+    # 중앙 텍스트
+    total = sum(counts_f)
+    ax.text(0, 0, f'{total}\nSignals', ha='center', va='center',
+            fontsize=16, fontweight='bold', color='#e5e7eb')
+
+    ax.set_title('Signal Distribution', color='#e5e7eb', fontsize=14,
+                 fontweight='bold', pad=20)
+
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', dpi=150, facecolor='#1a1f3a', bbox_inches='tight')
+    buf.seek(0)
+    plt.close(fig)
+
+    return buf.getvalue()
+
+
+def generate_sector_performance_chart(sector_data: List[Dict[str, Any]]) -> bytes:
+    """
+    섹터별 성과 수평 바 차트 생성
+
+    Args:
+        sector_data: [{'sector': str, 'avgReturn': float}, ...]
+
+    Returns:
+        PNG 이미지 바이트
+    """
+    fig, ax = plt.subplots(figsize=(10, 6), facecolor='#1a1f3a')
+    ax.set_facecolor('#0a0e27')
+
+    if not sector_data:
+        sector_data = [{'sector': 'No Data', 'avgReturn': 0}]
+
+    # 수익률 순 정렬
+    sector_data = sorted(sector_data, key=lambda x: x.get('avgReturn', 0))
+
+    sectors = [d['sector'] for d in sector_data]
+    returns = [d.get('avgReturn', 0) for d in sector_data]
+    bar_colors = ['#10b981' if r >= 0 else '#ef4444' for r in returns]
+
+    bars = ax.barh(sectors, returns, color=bar_colors, alpha=0.85, height=0.6,
+                   edgecolor='#2a2f4a', linewidth=0.5)
+
+    # 값 라벨
+    for bar, value in zip(bars, returns):
+        width = bar.get_width()
+        x_pos = width + 0.2 if width >= 0 else width - 0.2
+        ha = 'left' if width >= 0 else 'right'
+        ax.text(x_pos, bar.get_y() + bar.get_height() / 2,
+                f'{value:+.1f}%', ha=ha, va='center',
+                color='#e5e7eb', fontsize=10, fontweight='bold')
+
+    ax.axvline(x=0, color='#9aa0a6', linestyle='-', linewidth=1)
+
+    ax.set_xlabel('Avg Expected Return (%)', color='#9aa0a6', fontsize=11)
+    ax.set_title('Sector Performance', color='#e5e7eb', fontsize=14,
+                 fontweight='bold', pad=20)
+    ax.tick_params(colors='#9aa0a6', labelsize=10)
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['left'].set_color('#2a2f4a')
+    ax.spines['bottom'].set_color('#2a2f4a')
+    ax.grid(True, alpha=0.1, color='#9aa0a6', axis='x')
+
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', dpi=150, facecolor='#1a1f3a', bbox_inches='tight')
+    buf.seek(0)
+    plt.close(fig)
+
+    return buf.getvalue()
+
+
+def generate_confidence_gauge(score: float) -> bytes:
+    """
+    신뢰도 게이지 차트 생성 (반원형)
+
+    Args:
+        score: 신뢰도 점수 (0~100)
+
+    Returns:
+        PNG 이미지 바이트
+    """
+    fig, ax = plt.subplots(figsize=(6, 4), facecolor='#1a1f3a')
+
+    score = max(0, min(100, score))
+
+    # 반원형 배경 (구간별 색상)
+    segments = [
+        (0, 30, '#ef4444'),     # 빨강 (Low)
+        (30, 60, '#f59e0b'),    # 주황 (Medium)
+        (60, 80, '#10b981'),    # 초록 (Good)
+        (80, 100, '#059669'),   # 진한 초록 (Excellent)
+    ]
+
+    for start, end, color in segments:
+        theta_start = np.pi * (1 - end / 100)
+        theta_end = np.pi * (1 - start / 100)
+        theta = np.linspace(theta_start, theta_end, 50)
+        x_outer = 1.0 * np.cos(theta)
+        y_outer = 1.0 * np.sin(theta)
+        x_inner = 0.6 * np.cos(theta)
+        y_inner = 0.6 * np.sin(theta)
+        ax.fill(
+            np.concatenate([x_outer, x_inner[::-1]]),
+            np.concatenate([y_outer, y_inner[::-1]]),
+            color=color, alpha=0.3
+        )
+
+    # 점수 영역 (채워진 부분)
+    for start, end, color in segments:
+        actual_end = min(end, score)
+        if actual_end <= start:
+            continue
+        theta_start = np.pi * (1 - actual_end / 100)
+        theta_end = np.pi * (1 - start / 100)
+        theta = np.linspace(theta_start, theta_end, 50)
+        x_outer = 1.0 * np.cos(theta)
+        y_outer = 1.0 * np.sin(theta)
+        x_inner = 0.6 * np.cos(theta)
+        y_inner = 0.6 * np.sin(theta)
+        ax.fill(
+            np.concatenate([x_outer, x_inner[::-1]]),
+            np.concatenate([y_outer, y_inner[::-1]]),
+            color=color, alpha=0.9
+        )
+
+    # 바늘
+    needle_angle = np.pi * (1 - score / 100)
+    ax.plot([0, 0.55 * np.cos(needle_angle)], [0, 0.55 * np.sin(needle_angle)],
+            color='#e5e7eb', linewidth=3, solid_capstyle='round')
+    ax.plot(0, 0, 'o', color='#e5e7eb', markersize=8, zorder=5)
+
+    # 점수 텍스트
+    if score >= 80:
+        score_color = '#059669'
+    elif score >= 60:
+        score_color = '#10b981'
+    elif score >= 30:
+        score_color = '#f59e0b'
+    else:
+        score_color = '#ef4444'
+
+    ax.text(0, -0.15, f'{score:.0f}%', ha='center', va='center',
+            fontsize=28, fontweight='bold', color=score_color)
+    ax.text(0, -0.35, 'Confidence', ha='center', va='center',
+            fontsize=12, color='#9aa0a6')
+
+    # 구간 라벨
+    ax.text(-1.05, -0.05, '0', ha='center', color='#9aa0a6', fontsize=9)
+    ax.text(1.05, -0.05, '100', ha='center', color='#9aa0a6', fontsize=9)
+
+    ax.set_xlim(-1.3, 1.3)
+    ax.set_ylim(-0.5, 1.15)
+    ax.set_aspect('equal')
+    ax.axis('off')
+
+    ax.set_title('Model Confidence Score', color='#e5e7eb', fontsize=14,
+                 fontweight='bold', pad=10)
+
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', dpi=150, facecolor='#1a1f3a', bbox_inches='tight')
+    buf.seek(0)
+    plt.close(fig)
+
+    return buf.getvalue()

--- a/src/services/email_service.py
+++ b/src/services/email_service.py
@@ -1,15 +1,16 @@
 """SES 이메일 전송 서비스"""
 import boto3
 from typing import Optional
-import os
+import traceback
 
 
 class EmailService:
     """AWS SES를 사용한 이메일 전송 클래스"""
 
     def __init__(self):
-        self.ses = boto3.client('ses', region_name='ap-northeast-2')
-        self.from_email = os.getenv('SES_FROM_EMAIL', 'yyyyjw@naver.com')
+        from ..config import settings
+        self.ses = boto3.client('ses', region_name=settings.AWS_REGION)
+        self.from_email = settings.SES_FROM_EMAIL
         print(f"✅ SES 이메일 서비스 초기화: {self.from_email}")
 
     def send_welcome_email(self, to_email: str) -> bool:
@@ -192,8 +193,8 @@ StockPlay Team
             return True
 
         except Exception as e:
-            print(f"❌ 환영 이메일 전송 실패: {to_email} - {e}")
-            import traceback
+            print(f"❌ 환영 이메일 전송 실패: {to_email} - {type(e).__name__}: {e}")
+            print(f"   발신자: {self.from_email}")
             traceback.print_exc()
             return False
 

--- a/src/services/pdf_generator.py
+++ b/src/services/pdf_generator.py
@@ -2,14 +2,14 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import inch
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, Image
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, Image, PageBreak, HRFlowable
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.lib.enums import TA_CENTER, TA_LEFT
+from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT
 from datetime import datetime
 import io
 import os
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 
 # 한글 폰트 등록 (캐싱)
@@ -249,173 +249,333 @@ def generate_dashboard_pdf(signal_data: Dict[str, Any]) -> bytes:
     return buffer.getvalue()
 
 
-def generate_full_report_pdf(signal_data: Dict[str, Any], ai_analysis: Optional[Dict[str, str]] = None) -> bytes:
-    """
-    Reports용 상세 PDF 생성 (AI 분석 포함)
-    
-    Args:
-        signal_data: 시그널 데이터
-        ai_analysis: AI 분석 결과 (optional)
-        
-    Returns:
-        PDF 바이트 데이터
-    """
-    register_korean_fonts()
-    
-    buffer = io.BytesIO()
-    doc = SimpleDocTemplate(
-        buffer,
-        pagesize=A4,
-        rightMargin=0.75*inch,
-        leftMargin=0.75*inch,
-        topMargin=0.75*inch,
-        bottomMargin=0.75*inch,
-    )
-    
-    story = []
-    styles = getSampleStyleSheet()
-    
-    # 커스텀 스타일
-    title_style = ParagraphStyle(
-        'CustomTitle',
-        parent=styles['Title'],
-        fontSize=22,
-        textColor=colors.HexColor('#4c6fff'),
-        spaceAfter=20,
-        alignment=TA_CENTER,
-        fontName='NanumGothic-Bold',
-    )
-    
-    heading_style = ParagraphStyle(
-        'CustomHeading',
-        parent=styles['Heading2'],
-        fontSize=14,
-        textColor=colors.HexColor('#1a1f3a'),
-        spaceAfter=10,
-        spaceBefore=15,
-        fontName='NanumGothic-Bold',
-    )
-    
-    normal_style = ParagraphStyle(
-        'CustomNormal',
-        parent=styles['Normal'],
-        fontSize=10,
-        textColor=colors.HexColor('#1a1f3a'),
-        fontName='NanumGothic',
-        leading=14,
-    )
+def _build_premium_styles(styles):
+    """프리미엄 리포트용 스타일 모음"""
+    return {
+        'title': ParagraphStyle(
+            'PremiumTitle', parent=styles['Title'],
+            fontSize=26, textColor=colors.HexColor('#ffffff'),
+            spaceAfter=10, alignment=TA_CENTER,
+            fontName='NanumGothic-Bold',
+        ),
+        'subtitle': ParagraphStyle(
+            'PremiumSubtitle', parent=styles['Normal'],
+            fontSize=12, textColor=colors.HexColor('#b0b8ff'),
+            alignment=TA_CENTER, fontName='NanumGothic',
+        ),
+        'heading': ParagraphStyle(
+            'PremiumHeading', parent=styles['Heading2'],
+            fontSize=15, textColor=colors.HexColor('#4c6fff'),
+            spaceAfter=10, spaceBefore=15,
+            fontName='NanumGothic-Bold',
+        ),
+        'subheading': ParagraphStyle(
+            'PremiumSubheading', parent=styles['Heading3'],
+            fontSize=12, textColor=colors.HexColor('#1a1f3a'),
+            spaceAfter=8, spaceBefore=10,
+            fontName='NanumGothic-Bold',
+        ),
+        'normal': ParagraphStyle(
+            'PremiumNormal', parent=styles['Normal'],
+            fontSize=10, textColor=colors.HexColor('#1a1f3a'),
+            fontName='NanumGothic', leading=15,
+        ),
+        'small': ParagraphStyle(
+            'PremiumSmall', parent=styles['Normal'],
+            fontSize=8, textColor=colors.HexColor('#666666'),
+            fontName='NanumGothic', leading=11,
+        ),
+        'footer': ParagraphStyle(
+            'PremiumFooter', parent=styles['Normal'],
+            fontSize=8, textColor=colors.grey,
+            alignment=TA_CENTER, fontName='NanumGothic',
+        ),
+        'metric_value': ParagraphStyle(
+            'MetricValue', parent=styles['Normal'],
+            fontSize=20, textColor=colors.HexColor('#4c6fff'),
+            alignment=TA_CENTER, fontName='NanumGothic-Bold',
+        ),
+        'metric_label': ParagraphStyle(
+            'MetricLabel', parent=styles['Normal'],
+            fontSize=9, textColor=colors.HexColor('#666666'),
+            alignment=TA_CENTER, fontName='NanumGothic',
+        ),
+    }
 
-    # 0. 로고 (상단 중앙)
+
+def _build_page1_cover(story, signal_data, ps):
+    """Page 1: Cover + Summary"""
+
+    # 그라디언트 헤더 (테이블 배경으로 시뮬레이션)
+    header_data = [['']]
+    header_table = Table(header_data, colWidths=[6.5*inch], rowHeights=[1.8*inch])
+    header_table.setStyle(TableStyle([
+        ('BACKGROUND', (0, 0), (-1, -1), colors.HexColor('#4c6fff')),
+        ('TOPPADDING', (0, 0), (-1, -1), 0),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 0),
+    ]))
+    story.append(header_table)
+
+    # 로고 + 타이틀 (헤더 위에 겹치기는 어려우므로 별도 배치)
     logo_image_data = get_logo_image()
     if logo_image_data:
         try:
-            logo = Image(logo_image_data, width=2*inch, height=2*inch)
+            logo = Image(logo_image_data, width=1.2*inch, height=1.2*inch)
             logo.hAlign = 'CENTER'
+            story.append(Spacer(1, -1.6*inch))
             story.append(logo)
-            story.append(Spacer(1, 0.3*inch))
-        except Exception as e:
-            print(f"로고 추가 실패: {e}")
+        except Exception:
+            pass
 
-    # 1. 제목
-    title = Paragraph(f"<b>StockPlay 전문 투자 리포트</b>", title_style)
-    story.append(title)
-    
-    subtitle = Paragraph(f"AI 기반 상세 분석 리포트", normal_style)
-    story.append(subtitle)
+    story.append(Paragraph("<b>StockPlay Premium Report</b>", ps['title']))
+    story.append(Paragraph("AI-Powered Investment Analysis", ps['subtitle']))
+    story.append(Spacer(1, 0.4*inch))
+
+    # 날짜 + 기간 정보
+    company_name = signal_data.get('companyName', 'N/A')
+    symbol = signal_data.get('symbol', 'N/A')
+    signal_type = signal_data.get('signalType', 'BUY')
+    period = signal_data.get('period', '1d')
+
+    # 종목 정보 바
+    info_text = f"""
+    <b>{company_name}</b> ({symbol}) | {signal_data.get('sector', 'N/A')} |
+    {datetime.now().strftime('%Y.%m.%d')} | {period}
+    """
+    story.append(Paragraph(info_text, ParagraphStyle(
+        'InfoBar', parent=ps['normal'], alignment=TA_CENTER,
+        fontSize=11, textColor=colors.HexColor('#333333'),
+        fontName='NanumGothic',
+    )))
+    story.append(Spacer(1, 0.1*inch))
+
+    # 시그널 배지
+    signal_colors = {'BUY': '#10b981', 'HOLD': '#f59e0b', 'SELL': '#ef4444'}
+    signal_labels = {'BUY': 'BUY (매수)', 'HOLD': 'HOLD (관망)', 'SELL': 'SELL (매도)'}
+    badge_color = colors.HexColor(signal_colors.get(signal_type, '#4c6fff'))
+
+    badge_data = [[signal_labels.get(signal_type, signal_type)]]
+    badge_table = Table(badge_data, colWidths=[2.5*inch], rowHeights=[0.4*inch])
+    badge_table.setStyle(TableStyle([
+        ('BACKGROUND', (0, 0), (-1, -1), badge_color),
+        ('TEXTCOLOR', (0, 0), (-1, -1), colors.white),
+        ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
+        ('FONTNAME', (0, 0), (-1, -1), 'NanumGothic-Bold'),
+        ('FONTSIZE', (0, 0), (-1, -1), 14),
+        ('ROUNDEDCORNERS', [8, 8, 8, 8]),
+    ]))
+    badge_table.hAlign = 'CENTER'
+    story.append(badge_table)
+    story.append(Spacer(1, 0.4*inch))
+
+    # 핵심 지표 카드 3개
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.HexColor('#e0e0e0')))
+    story.append(Spacer(1, 0.2*inch))
+
+    expected_return = signal_data.get('expectedReturn', 0)
+    vs_kospi = signal_data.get('vsKospi', 0)
+    confidence = signal_data.get('confidenceScore', 0)
+
+    ret_color = '#10b981' if expected_return >= 0 else '#ef4444'
+    vs_color = '#10b981' if vs_kospi >= 0 else '#ef4444'
+    conf_color = '#10b981' if confidence >= 70 else ('#f59e0b' if confidence >= 40 else '#ef4444')
+
+    metric_data = [
+        [
+            Paragraph(f'<font color="{ret_color}"><b>{expected_return:+.1f}%</b></font>', ps['metric_value']),
+            Paragraph(f'<font color="{vs_color}"><b>{vs_kospi:+.1f}%p</b></font>', ps['metric_value']),
+            Paragraph(f'<font color="{conf_color}"><b>{confidence:.0f}%</b></font>', ps['metric_value']),
+        ],
+        [
+            Paragraph('Expected Return', ps['metric_label']),
+            Paragraph('vs KOSPI', ps['metric_label']),
+            Paragraph('Confidence', ps['metric_label']),
+        ]
+    ]
+
+    metric_table = Table(metric_data, colWidths=[2.17*inch, 2.17*inch, 2.17*inch])
+    metric_table.setStyle(TableStyle([
+        ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
+        ('TOPPADDING', (0, 0), (-1, 0), 15),
+        ('BOTTOMPADDING', (0, 0), (-1, 0), 5),
+        ('TOPPADDING', (0, 1), (-1, 1), 2),
+        ('BOTTOMPADDING', (0, 1), (-1, 1), 15),
+        ('LINEAFTER', (0, 0), (1, -1), 1, colors.HexColor('#e0e0e0')),
+    ]))
+    story.append(metric_table)
+
+    story.append(Spacer(1, 0.15*inch))
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.HexColor('#e0e0e0')))
     story.append(Spacer(1, 0.3*inch))
-    
-    # 2. 종목 개요
-    story.append(Paragraph("📊 종목 개요", heading_style))
-    
-    signal_type_kr = {
-        'BUY': '매수 (강력 추천)',
-        'HOLD': '홀드 (관망)',
-        'SELL': '매도 (주의)'
-    }.get(signal_data.get('signalType', 'BUY'), '매수')
-    
+
+    # 추가 지표
+    extra_data = [
+        ['Surprise Z-Score', 'YoY Growth', 'KOSPI Return'],
+        [f"{signal_data.get('surpriseZ', 0):.2f}",
+         f"{signal_data.get('yoyGrowth', 0):.1f}%",
+         f"{signal_data.get('kospiReturn', 0):+.1f}%"],
+    ]
+
+    extra_table = Table(extra_data, colWidths=[2.17*inch, 2.17*inch, 2.17*inch])
+    extra_table.setStyle(TableStyle([
+        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#f0f4ff')),
+        ('TEXTCOLOR', (0, 0), (-1, 0), colors.HexColor('#4c6fff')),
+        ('TEXTCOLOR', (0, 1), (-1, 1), colors.HexColor('#1a1f3a')),
+        ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+        ('FONTNAME', (0, 0), (-1, 0), 'NanumGothic-Bold'),
+        ('FONTNAME', (0, 1), (-1, 1), 'NanumGothic'),
+        ('FONTSIZE', (0, 0), (-1, 0), 10),
+        ('FONTSIZE', (0, 1), (-1, 1), 13),
+        ('TOPPADDING', (0, 0), (-1, -1), 10),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 10),
+        ('GRID', (0, 0), (-1, -1), 1, colors.HexColor('#e0e0e0')),
+    ]))
+    story.append(extra_table)
+
+
+def _build_page2_technical(story, signal_data, ps):
+    """Page 2: Technical Analysis Charts"""
+    story.append(PageBreak())
+
+    story.append(Paragraph("Technical Analysis", ps['heading']))
+    story.append(HRFlowable(width="100%", thickness=2, color=colors.HexColor('#4c6fff')))
+    story.append(Spacer(1, 0.2*inch))
+
+    # 1. KOSPI Advanced Chart
+    story.append(Paragraph("KOSPI Market Analysis", ps['subheading']))
+    try:
+        from .chart_generator import generate_kospi_advanced_chart
+        kospi_chart_bytes = generate_kospi_advanced_chart(signal_data, days=60)
+        kospi_img = Image(io.BytesIO(kospi_chart_bytes), width=6.5*inch, height=3.5*inch)
+        kospi_img.hAlign = 'CENTER'
+        story.append(kospi_img)
+    except Exception as e:
+        print(f"⚠️ KOSPI advanced chart failed: {e}")
+        try:
+            from .chart_generator_pillow import generate_kospi_chart_pillow
+            fallback = generate_kospi_chart_pillow(signal_data, days=60)
+            fb_img = Image(io.BytesIO(fallback), width=6.5*inch, height=3.25*inch)
+            fb_img.hAlign = 'CENTER'
+            story.append(fb_img)
+        except Exception as e2:
+            print(f"⚠️ Pillow chart fallback also failed: {e2}")
+            story.append(Paragraph("KOSPI chart unavailable", ps['small']))
+
+    story.append(Spacer(1, 0.25*inch))
+
+    # 2. Surprise Z-Score + KOSPI Comparison (나란히는 어려우므로 순서대로)
+    story.append(Paragraph("Surprise Z-Score Timeline", ps['subheading']))
+    try:
+        from .chart_generator import generate_surprise_chart
+        surprise_bytes = generate_surprise_chart(signal_data, history_days=30)
+        surprise_img = Image(io.BytesIO(surprise_bytes), width=6.5*inch, height=3*inch)
+        surprise_img.hAlign = 'CENTER'
+        story.append(surprise_img)
+    except Exception as e:
+        print(f"⚠️ Surprise chart failed: {e}")
+        story.append(Paragraph("Surprise Z-Score chart unavailable", ps['small']))
+
+    story.append(Spacer(1, 0.25*inch))
+
+    story.append(Paragraph("Performance vs KOSPI", ps['subheading']))
+    try:
+        from .chart_generator import generate_kospi_comparison_chart
+        comparison_bytes = generate_kospi_comparison_chart(signal_data)
+        comp_img = Image(io.BytesIO(comparison_bytes), width=6.5*inch, height=3*inch)
+        comp_img.hAlign = 'CENTER'
+        story.append(comp_img)
+    except Exception as e:
+        print(f"⚠️ Comparison chart failed: {e}")
+        story.append(Paragraph("Comparison chart unavailable", ps['small']))
+
+
+def _build_page3_analysis(story, signal_data, ai_analysis, ps):
+    """Page 3: AI Analysis + Risk + Technical Table"""
+    story.append(PageBreak())
+
+    story.append(Paragraph("AI Analysis & Risk Assessment", ps['heading']))
+    story.append(HRFlowable(width="100%", thickness=2, color=colors.HexColor('#4c6fff')))
+    story.append(Spacer(1, 0.2*inch))
+
     company_name = signal_data.get('companyName', 'N/A')
     symbol = signal_data.get('symbol', 'N/A')
 
-    overview_text = f"""
-    <b>종목:</b> {company_name} ({symbol})<br/>
-    <b>업종:</b> {signal_data.get('sector', 'N/A')}<br/>
-    <b>투자의견:</b> {signal_type_kr}<br/>
-    <b>예측기간:</b> {signal_data.get('period', '1d')}<br/>
-    <br/>
-    """
+    # 1. AI 투자 의견
+    story.append(Paragraph("AI Investment Opinion", ps['subheading']))
 
     if ai_analysis and 'overview' in ai_analysis:
-        overview_text += ai_analysis['overview']
+        story.append(Paragraph(ai_analysis['overview'], ps['normal']))
     else:
-        overview_text += f"""
+        overview = f"""
         {company_name}({symbol})은(는) {signal_data.get('sector')} 섹터의 종목으로,
         최근 Surprise 지표가 {signal_data.get('surpriseZ', 0):.2f}를 기록하며
         {'긍정적인' if signal_data.get('surpriseZ', 0) > 0 else '부정적인'} 신호를 보이고 있습니다.
         """
-    
-    story.append(Paragraph(overview_text, normal_style))
-    story.append(Spacer(1, 0.3*inch))
-    
-    # 3. 투자 의견
-    story.append(Paragraph("💡 투자 의견", heading_style))
-    
+        story.append(Paragraph(overview, ps['normal']))
+
+    story.append(Spacer(1, 0.1*inch))
+
     if ai_analysis and 'investment_opinion' in ai_analysis:
-        opinion_text = ai_analysis['investment_opinion']
+        story.append(Paragraph(ai_analysis['investment_opinion'], ps['normal']))
     else:
         expected = signal_data.get('expectedReturn', 0)
         vs_kospi = signal_data.get('vsKospi', 0)
-        
-        opinion_text = f"""
+        opinion = f"""
         <b>{signal_data.get('period', '1d')} 기준 예상 수익률:</b> {expected:+.1f}%<br/>
         <b>KOSPI 대비:</b> {vs_kospi:+.1f}%p<br/>
-        <br/>
-        본 종목은 {signal_data.get('period')} 기간 동안 {expected:+.1f}%의 수익률이 예상되며,
-        이는 KOSPI 대비 {abs(vs_kospi):.1f}%p {'높은' if vs_kospi > 0 else '낮은'} 수준입니다.
-        현재 시장 상황을 고려할 때 {'매수' if expected > 0 else '매도'} 포지션을 권장합니다.
+        본 종목은 KOSPI 대비 {abs(vs_kospi):.1f}%p {'높은' if vs_kospi > 0 else '낮은'} 수준입니다.
         """
-    
-    story.append(Paragraph(opinion_text, normal_style))
-    story.append(Spacer(1, 0.3*inch))
-    
-    # 4. 리스크 분석
-    story.append(Paragraph("⚠️ 리스크 분석", heading_style))
-    
+        story.append(Paragraph(opinion, ps['normal']))
+
+    story.append(Spacer(1, 0.25*inch))
+
+    # 2. 리스크 분석
+    story.append(Paragraph("Risk Analysis", ps['subheading']))
+
     if ai_analysis and 'risk_analysis' in ai_analysis:
-        risk_text = ai_analysis['risk_analysis']
+        story.append(Paragraph(ai_analysis['risk_analysis'], ps['normal']))
     else:
         confidence = signal_data.get('confidenceScore', 0)
-        risk_text = f"""
-        <b>신뢰도:</b> {confidence:.0f}%<br/>
-        <br/>
-        주요 리스크 요인:<br/>
-        • 시장 변동성에 따른 예측 오차 가능성<br/>
-        • 예상 수익률은 과거 데이터 기반이며 미래 보장 불가<br/>
-        • 거시경제 및 산업 트렌드 변화 리스크<br/>
+        risk = f"""
+        <b>Model Confidence:</b> {confidence:.0f}%<br/><br/>
+        Risk Factors:<br/>
+        - Market volatility may affect prediction accuracy<br/>
+        - Expected returns are based on historical data and do not guarantee future results<br/>
+        - Macroeconomic and sector trend changes may impact performance<br/>
+        - Surprise Z-Score patterns may shift in unusual market conditions<br/>
         """
-    
-    story.append(Paragraph(risk_text, normal_style))
-    story.append(Spacer(1, 0.3*inch))
-    
-    # 5. 기술적 지표
-    story.append(Paragraph("📈 기술적 지표", heading_style))
-    
-    if ai_analysis and 'technical_analysis' in ai_analysis:
-        tech_text = ai_analysis['technical_analysis']
-        story.append(Paragraph(tech_text, normal_style))
-    
-    story.append(Spacer(1, 0.2*inch))
-    
+        story.append(Paragraph(risk, ps['normal']))
+
+    story.append(Spacer(1, 0.25*inch))
+
+    # 3. Confidence Gauge
+    try:
+        from .chart_generator import generate_confidence_gauge
+        gauge_bytes = generate_confidence_gauge(signal_data.get('confidenceScore', 0))
+        gauge_img = Image(io.BytesIO(gauge_bytes), width=3*inch, height=2*inch)
+        gauge_img.hAlign = 'CENTER'
+        story.append(gauge_img)
+        story.append(Spacer(1, 0.2*inch))
+    except Exception as e:
+        print(f"⚠️ Confidence gauge failed: {e}")
+
+    # 4. 기술적 지표 테이블
+    story.append(Paragraph("Technical Indicators", ps['subheading']))
+
     technical_data = [
-        ['지표', '값', '의미'],
-        ['Surprise Z-Score', f"{signal_data.get('surpriseZ', 0):.2f}", 
-         '높을수록 긍정' if signal_data.get('surpriseZ', 0) > 0 else '낮을수록 부정'],
-        ['YoY 성장률', f"{signal_data.get('yoyGrowth', 0):.1f}%", '전년 대비 성장'],
-        ['예상 수익률', f"{signal_data.get('expectedReturn', 0):+.1f}%", '예측 수익'],
-        ['KOSPI 대비', f"{signal_data.get('vsKospi', 0):+.1f}%", '지수 대비 성과'],
-        ['신뢰도', f"{signal_data.get('confidenceScore', 0):.0f}%", '모델 신뢰도'],
+        ['Indicator', 'Value', 'Interpretation'],
+        ['Surprise Z-Score', f"{signal_data.get('surpriseZ', 0):.2f}",
+         'Positive signal' if signal_data.get('surpriseZ', 0) > 0 else 'Negative signal'],
+        ['YoY Growth', f"{signal_data.get('yoyGrowth', 0):.1f}%", 'Year-over-Year growth rate'],
+        ['Expected Return', f"{signal_data.get('expectedReturn', 0):+.1f}%", 'Predicted return'],
+        ['vs KOSPI', f"{signal_data.get('vsKospi', 0):+.1f}%p", 'Relative to market index'],
+        ['KOSPI Return', f"{signal_data.get('kospiReturn', 0):+.1f}%", 'Market benchmark'],
+        ['Confidence', f"{signal_data.get('confidenceScore', 0):.0f}%", 'Model confidence level'],
     ]
-    
-    tech_table = Table(technical_data, colWidths=[2*inch, 1.8*inch, 2.2*inch])
+
+    tech_table = Table(technical_data, colWidths=[2*inch, 1.5*inch, 3*inch])
     tech_table.setStyle(TableStyle([
         ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#4c6fff')),
         ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
@@ -424,74 +584,80 @@ def generate_full_report_pdf(signal_data: Dict[str, Any], ai_analysis: Optional[
         ('FONTSIZE', (0, 0), (-1, 0), 10),
         ('BOTTOMPADDING', (0, 0), (-1, 0), 10),
         ('TOPPADDING', (0, 0), (-1, 0), 10),
-        ('BACKGROUND', (0, 1), (-1, -1), colors.HexColor('#f0f4ff')),
+        ('BACKGROUND', (0, 1), (-1, -1), colors.HexColor('#f8f9ff')),
         ('TEXTCOLOR', (0, 1), (-1, -1), colors.HexColor('#1a1f3a')),
         ('FONTNAME', (0, 1), (-1, -1), 'NanumGothic'),
         ('FONTSIZE', (0, 1), (-1, -1), 9),
         ('TOPPADDING', (0, 1), (-1, -1), 8),
         ('BOTTOMPADDING', (0, 1), (-1, -1), 8),
-        ('GRID', (0, 0), (-1, -1), 1, colors.grey),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.HexColor('#d0d0d0')),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.HexColor('#f8f9ff'), colors.HexColor('#ffffff')]),
     ]))
-    
+
     story.append(tech_table)
     story.append(Spacer(1, 0.4*inch))
 
-    # 6. KOSPI 기술적 분석 차트
-    story.append(Paragraph("📊 KOSPI 시장 분석", heading_style))
+    # 5. 면책 조항
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.HexColor('#e0e0e0')))
+    story.append(Spacer(1, 0.1*inch))
 
-    try:
-        from .chart_generator_pillow import generate_kospi_chart_pillow
-
-        kospi_chart_bytes = generate_kospi_chart_pillow(signal_data, days=60)
-        kospi_chart_img = Image(io.BytesIO(kospi_chart_bytes), width=6.5*inch, height=3.25*inch)
-        kospi_chart_img.hAlign = 'CENTER'
-        story.append(kospi_chart_img)
-        story.append(Spacer(1, 0.3*inch))
-
-        # 차트 설명
-        chart_desc = """
-        위 차트는 최근 60일간의 KOSPI 지수 추이를 보여줍니다.<br/>
-        • 현재 KOSPI 지수 수준과 최근 추세를 확인할 수 있습니다<br/>
-        • 주황색 점은 현재 시점의 KOSPI 지수입니다<br/>
-        """
-        story.append(Paragraph(chart_desc, normal_style))
-        story.append(Spacer(1, 0.3*inch))
-
-    except Exception as e:
-        print(f"⚠️ KOSPI 차트 생성 실패: {e}")
-        import traceback
-        traceback.print_exc()
-        # 오류가 발생해도 리포트는 계속 생성 (차트 없이)
-        error_text = f"차트 생성 중 일시적 오류가 발생했습니다. 데이터는 정상적으로 분석되었습니다."
-        story.append(Paragraph(error_text, normal_style))
-        story.append(Spacer(1, 0.3*inch))
-
-    # 7. 푸터
-    footer_style = ParagraphStyle(
-        'Footer',
-        parent=styles['Normal'],
-        fontSize=8,
-        textColor=colors.grey,
-        alignment=TA_CENTER,
-        fontName='NanumGothic',
-    )
-    
-    footer_text = f"""
+    disclaimer = f"""
+    <b>Disclaimer</b><br/>
+    This report is generated by StockPlay AI for reference purposes only.
+    Investment decisions and their outcomes are the sole responsibility of the investor.
+    Past performance does not guarantee future results.
+    StockPlay provides data analysis and does not bear responsibility for investment losses.<br/>
     <br/>
-    <b>생성일:</b> {datetime.now().strftime('%Y년 %m월 %d일 %H:%M')}<br/>
-    <br/>
-    ⚠️ 본 리포트는 AI 분석 기반 참고 자료이며, 투자 판단 및 결과에 대한 책임은 투자자 본인에게 있습니다.<br/>
-    StockPlay는 데이터 분석을 제공할 뿐, 투자 손실에 대한 책임을 지지 않습니다.<br/>
-    <br/>
-    Generated by StockPlay AI<br/>
-    📊 자세한 차트는 웹사이트에서 확인하세요
+    <b>Generated:</b> {datetime.now().strftime('%Y-%m-%d %H:%M:%S KST')}<br/>
+    © 2025 StockPlay. All rights reserved.
     """
-    
-    story.append(Paragraph(footer_text, footer_style))
-    
+    story.append(Paragraph(disclaimer, ps['footer']))
+
+
+def generate_full_report_pdf(signal_data: Dict[str, Any], ai_analysis: Optional[Dict[str, str]] = None) -> bytes:
+    """
+    프리미엄 멀티페이지 PDF 생성
+
+    Page 1: Cover + Summary (핵심 지표 카드, 시그널 배지)
+    Page 2: Technical Analysis (KOSPI Advanced, Surprise Z-Score, Comparison)
+    Page 3: AI Analysis + Risk + Technical Table + Disclaimer
+
+    Args:
+        signal_data: 시그널 데이터
+        ai_analysis: AI 분석 결과 (optional)
+
+    Returns:
+        PDF 바이트 데이터
+    """
+    register_korean_fonts()
+
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        rightMargin=0.5*inch,
+        leftMargin=0.5*inch,
+        topMargin=0.5*inch,
+        bottomMargin=0.5*inch,
+    )
+
+    styles = getSampleStyleSheet()
+    ps = _build_premium_styles(styles)
+
+    story = []
+
+    # Page 1: Cover + Summary
+    _build_page1_cover(story, signal_data, ps)
+
+    # Page 2: Technical Analysis Charts
+    _build_page2_technical(story, signal_data, ps)
+
+    # Page 3: AI Analysis + Risk
+    _build_page3_analysis(story, signal_data, ai_analysis, ps)
+
     doc.build(story)
     buffer.seek(0)
-    
+
     return buffer.getvalue()
 
 

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,7 @@ Resources:
           USE_S3_DATA: "true"
           S3_DATA_BUCKET: "stockplay-data-yjw-20251113"
           DYNAMODB_TABLE: "stockplay-main"
+          SES_FROM_EMAIL: "yyyyjw@naver.com"
           DEBUG: "false"
       Policies:
         - S3ReadPolicy:

--- a/tests/test_email_fix.py
+++ b/tests/test_email_fix.py
@@ -1,0 +1,346 @@
+"""이메일 수정 + 리포트 고도화 테스트"""
+import sys
+import os
+
+# 프로젝트 루트를 path에 추가
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+# ──────────────────────────────────────────────
+# 1. Config 테스트
+# ──────────────────────────────────────────────
+class TestConfig(unittest.TestCase):
+    def test_ses_from_email_exists(self):
+        """Settings 클래스에 SES_FROM_EMAIL 필드가 존재하고 기본값이 맞는지"""
+        from src.config import Settings
+        # 환경변수 오염 방지를 위해 새 인스턴스 생성
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('SES_FROM_EMAIL', None)
+            s = Settings()
+            self.assertTrue(hasattr(s, 'SES_FROM_EMAIL'))
+            self.assertEqual(s.SES_FROM_EMAIL, 'yyyyjw@naver.com')
+
+    def test_ses_from_email_env_override(self):
+        """환경변수로 오버라이드 가능한지"""
+        with patch.dict(os.environ, {'SES_FROM_EMAIL': 'test@test.com'}):
+            from src.config import Settings
+            s = Settings()
+            self.assertEqual(s.SES_FROM_EMAIL, 'test@test.com')
+
+
+# ──────────────────────────────────────────────
+# 2. template.yaml 테스트
+# ──────────────────────────────────────────────
+class TestTemplateYaml(unittest.TestCase):
+    def setUp(self):
+        template_path = os.path.join(os.path.dirname(__file__), '..', 'template.yaml')
+        with open(template_path, 'r') as f:
+            self.content = f.read()
+
+    def test_stockplay_api_has_ses_from_email(self):
+        """StockPlayAPI Lambda에 SES_FROM_EMAIL이 있는지"""
+        # StockPlayAPI 블록 찾기
+        lines = self.content.split('\n')
+        in_api_block = False
+        in_env_vars = False
+        found = False
+
+        for line in lines:
+            if 'StockPlayAPI:' in line:
+                in_api_block = True
+            elif in_api_block and 'EmailSenderFunction:' in line:
+                break
+            elif in_api_block and 'Variables:' in line:
+                in_env_vars = True
+            elif in_api_block and in_env_vars and 'SES_FROM_EMAIL' in line:
+                found = True
+                self.assertIn('yyyyjw@naver.com', line)
+                break
+
+        self.assertTrue(found, 'SES_FROM_EMAIL not found in StockPlayAPI environment')
+
+    def test_email_sender_has_ses_from_email(self):
+        """EmailSenderFunction에도 SES_FROM_EMAIL이 있는지"""
+        lines = self.content.split('\n')
+        in_email_block = False
+        found = False
+
+        for line in lines:
+            if 'EmailSenderFunction:' in line:
+                in_email_block = True
+            elif in_email_block and 'SES_FROM_EMAIL' in line:
+                found = True
+                self.assertIn('yyyyjw@naver.com', line)
+                break
+
+        self.assertTrue(found, 'SES_FROM_EMAIL not found in EmailSenderFunction')
+
+    def test_both_lambdas_same_email(self):
+        """두 Lambda의 SES_FROM_EMAIL이 동일한지"""
+        import re
+        matches = re.findall(r'SES_FROM_EMAIL:\s*"(.+?)"', self.content)
+        self.assertGreaterEqual(len(matches), 2, f'Expected 2+ SES_FROM_EMAIL entries, found {len(matches)}')
+        self.assertTrue(all(m == matches[0] for m in matches),
+                        f'SES_FROM_EMAIL values differ: {matches}')
+
+
+# ──────────────────────────────────────────────
+# 3. email_sender.py 기본값 테스트
+# ──────────────────────────────────────────────
+class TestEmailSenderDefaults(unittest.TestCase):
+    def test_default_from_email_not_noreply(self):
+        """email_sender.py 기본값이 noreply@stockplay.com이 아닌지"""
+        email_sender_path = os.path.join(os.path.dirname(__file__), '..', 'email_sender.py')
+        with open(email_sender_path, 'r') as f:
+            content = f.read()
+        self.assertNotIn("noreply@stockplay.com", content)
+        self.assertIn("yyyyjw@naver.com", content)
+
+
+# ──────────────────────────────────────────────
+# 4. Subscribe 스키마 테스트
+# ──────────────────────────────────────────────
+class TestSubscribeSchema(unittest.TestCase):
+    def test_email_sent_field_exists(self):
+        from src.schemas.subscribe import SubscriptionResponse
+        fields = SubscriptionResponse.model_fields
+        self.assertIn('email_sent', fields)
+
+    def test_email_sent_optional(self):
+        """email_sent는 Optional (기존 응답 호환)"""
+        from src.schemas.subscribe import SubscriptionResponse
+        resp = SubscriptionResponse(
+            email='test@test.com',
+            notification_enabled=True,
+            created_at='2025-01-01',
+            updated_at='2025-01-01',
+        )
+        self.assertIsNone(resp.email_sent)
+
+    def test_email_sent_with_value(self):
+        from src.schemas.subscribe import SubscriptionResponse
+        resp = SubscriptionResponse(
+            email='test@test.com',
+            notification_enabled=True,
+            created_at='2025-01-01',
+            updated_at='2025-01-01',
+            email_sent=True,
+        )
+        self.assertTrue(resp.email_sent)
+
+
+# ──────────────────────────────────────────────
+# 5. 차트 생성 테스트
+# ──────────────────────────────────────────────
+MOCK_SIGNAL = {
+    'symbol': '005930',
+    'companyName': 'Samsung Electronics',
+    'sector': 'IT',
+    'signalType': 'BUY',
+    'period': '1d',
+    'expectedReturn': 2.5,
+    'vsKospi': 1.2,
+    'kospiReturn': 1.3,
+    'surpriseZ': 2.1,
+    'yoyGrowth': 15.3,
+    'confidenceScore': 85.0
+}
+
+MOCK_SIGNALS_LIST = [
+    {'signalType': 'BUY', 'symbol': 'A', 'sector': 'IT', 'expectedReturn': 3.0},
+    {'signalType': 'BUY', 'symbol': 'B', 'sector': 'IT', 'expectedReturn': 2.0},
+    {'signalType': 'HOLD', 'symbol': 'C', 'sector': 'Finance', 'expectedReturn': 0.5},
+    {'signalType': 'SELL', 'symbol': 'D', 'sector': 'Energy', 'expectedReturn': -1.0},
+    {'signalType': 'BUY', 'symbol': 'E', 'sector': 'Healthcare', 'expectedReturn': 1.5},
+]
+
+
+class TestNewCharts(unittest.TestCase):
+    def test_signal_distribution_chart(self):
+        from src.services.chart_generator import generate_signal_distribution_chart
+        result = generate_signal_distribution_chart(MOCK_SIGNALS_LIST)
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 1000, 'Chart too small, likely empty')
+        # PNG 시그니처 확인
+        self.assertTrue(result[:4] == b'\x89PNG', 'Not a valid PNG')
+
+    def test_signal_distribution_empty(self):
+        """빈 리스트도 처리 가능한지"""
+        from src.services.chart_generator import generate_signal_distribution_chart
+        result = generate_signal_distribution_chart([])
+        self.assertIsInstance(result, bytes)
+        self.assertTrue(result[:4] == b'\x89PNG')
+
+    def test_sector_performance_chart(self):
+        from src.services.chart_generator import generate_sector_performance_chart
+        sector_data = [
+            {'sector': 'IT', 'avgReturn': 3.5},
+            {'sector': 'Finance', 'avgReturn': -1.2},
+            {'sector': 'Energy', 'avgReturn': 0.8},
+            {'sector': 'Healthcare', 'avgReturn': 2.1},
+        ]
+        result = generate_sector_performance_chart(sector_data)
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 1000)
+        self.assertTrue(result[:4] == b'\x89PNG')
+
+    def test_sector_performance_empty(self):
+        from src.services.chart_generator import generate_sector_performance_chart
+        result = generate_sector_performance_chart([])
+        self.assertIsInstance(result, bytes)
+        self.assertTrue(result[:4] == b'\x89PNG')
+
+    def test_confidence_gauge(self):
+        from src.services.chart_generator import generate_confidence_gauge
+        result = generate_confidence_gauge(85.0)
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 1000)
+        self.assertTrue(result[:4] == b'\x89PNG')
+
+    def test_confidence_gauge_boundaries(self):
+        """경계값 테스트 (0, 50, 100, 범위 초과)"""
+        from src.services.chart_generator import generate_confidence_gauge
+        for score in [0, 25, 50, 75, 100, -10, 150]:
+            result = generate_confidence_gauge(score)
+            self.assertIsInstance(result, bytes)
+            self.assertTrue(result[:4] == b'\x89PNG', f'Failed for score={score}')
+
+
+# ──────────────────────────────────────────────
+# 6. 프리미엄 PDF 생성 테스트
+# ──────────────────────────────────────────────
+class TestPremiumPdf(unittest.TestCase):
+    @patch('src.services.pdf_generator.get_logo_image', return_value=None)
+    def test_generate_without_ai(self, mock_logo):
+        """AI 분석 없이 PDF 생성"""
+        from src.services.pdf_generator import generate_full_report_pdf
+        result = generate_full_report_pdf(MOCK_SIGNAL, ai_analysis=None)
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 5000, 'PDF too small')
+        # PDF 시그니처 확인
+        self.assertTrue(result[:5] == b'%PDF-', 'Not a valid PDF')
+
+    @patch('src.services.pdf_generator.get_logo_image', return_value=None)
+    def test_generate_with_ai(self, mock_logo):
+        """AI 분석 포함 PDF 생성"""
+        from src.services.pdf_generator import generate_full_report_pdf
+        ai_analysis = {
+            'overview': 'This is an AI-generated overview of the stock.',
+            'investment_opinion': 'We recommend a BUY position based on current indicators.',
+            'risk_analysis': 'Market volatility remains a concern.',
+            'technical_analysis': 'Technical indicators are bullish.',
+        }
+        result = generate_full_report_pdf(MOCK_SIGNAL, ai_analysis=ai_analysis)
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 5000)
+        self.assertTrue(result[:5] == b'%PDF-')
+
+    @patch('src.services.pdf_generator.get_logo_image', return_value=None)
+    def test_pdf_multi_page(self, mock_logo):
+        """멀티페이지 확인 (PDF 내부에 PageBreak가 있으므로 크기로 간접 확인)"""
+        from src.services.pdf_generator import generate_full_report_pdf
+        result = generate_full_report_pdf(MOCK_SIGNAL)
+        # 멀티페이지 PDF는 단일 페이지보다 상당히 큼
+        self.assertGreater(len(result), 10000, 'PDF likely single page — expected multi-page')
+
+    @patch('src.services.pdf_generator.get_logo_image', return_value=None)
+    def test_sell_signal_pdf(self, mock_logo):
+        """SELL 시그널 데이터로도 정상 생성되는지"""
+        from src.services.pdf_generator import generate_full_report_pdf
+        sell_data = {**MOCK_SIGNAL, 'signalType': 'SELL', 'expectedReturn': -3.2, 'vsKospi': -4.5}
+        result = generate_full_report_pdf(sell_data)
+        self.assertIsInstance(result, bytes)
+        self.assertTrue(result[:5] == b'%PDF-')
+
+
+# ──────────────────────────────────────────────
+# 7. 이메일 HTML 테스트
+# ──────────────────────────────────────────────
+class TestEmailHtml(unittest.TestCase):
+    def test_html_has_signal_badges(self):
+        """HTML에 시그널 타입 배지가 포함되는지"""
+        # email_sender는 최상위 모듈이므로 직접 import
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+        from email_sender import generate_email_html
+
+        report_data = {
+            'topPicks': [
+                {'symbol': '005930', 'sector': 'IT', 'signalType': 'BUY',
+                 'expectedReturn': 3.0, 'confidenceScore': 85},
+                {'symbol': '000660', 'sector': 'IT', 'signalType': 'SELL',
+                 'expectedReturn': -1.5, 'confidenceScore': 70},
+            ],
+            'performance': {'avgReturn': 2.5, 'winRate': 72, 'sharpeRatio': 1.5}
+        }
+
+        html = generate_email_html(report_data)
+        self.assertIn('BUY', html)
+        self.assertIn('SELL', html)
+        self.assertIn('#10b981', html)  # BUY 색상
+        self.assertIn('#ef4444', html)  # SELL 색상
+
+    def test_html_has_performance_cards(self):
+        from email_sender import generate_email_html
+        report_data = {
+            'topPicks': [],
+            'performance': {'avgReturn': 5.3, 'winRate': 80, 'sharpeRatio': 2.1}
+        }
+        html = generate_email_html(report_data)
+        self.assertIn('Avg Return', html)
+        self.assertIn('Win Rate', html)
+        self.assertIn('Sharpe Ratio', html)
+
+    def test_html_has_distribution_bar(self):
+        from email_sender import generate_email_html
+        report_data = {
+            'topPicks': [
+                {'symbol': 'A', 'sector': 'IT', 'signalType': 'BUY', 'expectedReturn': 1, 'confidenceScore': 80},
+                {'symbol': 'B', 'sector': 'IT', 'signalType': 'BUY', 'expectedReturn': 2, 'confidenceScore': 85},
+                {'symbol': 'C', 'sector': 'FIN', 'signalType': 'HOLD', 'expectedReturn': 0, 'confidenceScore': 60},
+            ],
+            'performance': {'avgReturn': 1, 'winRate': 66, 'sharpeRatio': 1.0}
+        }
+        html = generate_email_html(report_data)
+        self.assertIn('Signal Distribution', html)
+        self.assertIn('BUY 2', html)
+        self.assertIn('HOLD 1', html)
+
+    def test_html_has_cta_button(self):
+        from email_sender import generate_email_html
+        report_data = {'topPicks': [], 'performance': {}}
+        html = generate_email_html(report_data)
+        self.assertIn('View Full Report', html)
+        self.assertIn('cloudfront.net', html)
+
+
+# ──────────────────────────────────────────────
+# 8. 기존 함수 하위 호환성 테스트
+# ──────────────────────────────────────────────
+class TestBackwardCompatibility(unittest.TestCase):
+    @patch('src.services.pdf_generator.get_logo_image', return_value=None)
+    def test_dashboard_pdf_still_works(self, mock_logo):
+        """기존 dashboard PDF 함수가 여전히 동작하는지"""
+        from src.services.pdf_generator import generate_dashboard_pdf
+        result = generate_dashboard_pdf(MOCK_SIGNAL)
+        self.assertIsInstance(result, bytes)
+        self.assertTrue(result[:5] == b'%PDF-')
+
+    def test_existing_chart_functions_still_work(self):
+        """기존 차트 함수들이 여전히 동작하는지"""
+        from src.services.chart_generator import (
+            generate_surprise_chart,
+            generate_kospi_comparison_chart,
+        )
+
+        surprise = generate_surprise_chart(MOCK_SIGNAL)
+        self.assertTrue(surprise[:4] == b'\x89PNG')
+
+        comparison = generate_kospi_comparison_chart(MOCK_SIGNAL)
+        self.assertTrue(comparison[:4] == b'\x89PNG')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- 기존 단일 페이지 텍스트+표 PDF를 **3페이지 프리미엄 리포트**로 전면 리뉴얼
- matplotlib 차트 3종 신규 추가 (도넛, 수평 바, 게이지)
- 기존 미사용 matplotlib 차트들(KOSPI Advanced, Surprise Z-Score, Comparison)을 PDF에 통합
- 이메일 HTML 리포트에 색상 코딩 시그널 배지, 성과 카드, 분포 바, CTA 버튼 추가
- 25개 유닛 테스트 추가

## Premium PDF Structure (3 Pages)

| Page | Content |
|---|---|
| **Page 1** | Cover + 시그널 배지(BUY/HOLD/SELL) + 핵심 지표 카드 3종 (수익률/KOSPI 대비/신뢰도) |
| **Page 2** | KOSPI Advanced Chart (MA20/MA60 + 추세선 + 지지/저항) + Surprise Z-Score Timeline + Performance vs KOSPI Bar Chart |
| **Page 3** | AI Analysis + Risk Assessment + Confidence Gauge + Technical Indicators Table + Disclaimer |

## New Charts (chart_generator.py)
- `generate_signal_distribution_chart` — BUY/HOLD/SELL 비율 도넛 차트
- `generate_sector_performance_chart` — 섹터별 평균 수익률 수평 바 차트
- `generate_confidence_gauge` — 반원형 신뢰도 게이지 (구간별 색상)

## Email HTML Upgrade (email_sender.py)
- Top 5 시그널 테이블에 색상 코딩 배지 (BUY=초록, SELL=빨강)
- 성과 지표 카드 레이아웃 (Avg Return / Win Rate / Sharpe)
- Signal Distribution 바 (CSS)
- "View Full Report" CTA 버튼

## Dependencies
- Depends on #18 (`fix/email-delivery`) — 이메일 수정이 먼저 머지되어야 함

## Test plan
- [x] 25/25 유닛 테스트 통과 (`python -m unittest tests.test_email_fix -v`)
- [ ] `POST /api/reports/generate` → PDF 다운로드 후 3페이지 확인
- [ ] 각 차트 렌더링 확인 (KOSPI, Z-Score, 비교, 도넛, 게이지)
- [ ] 이메일 HTML 레이아웃 확인 (색상 코딩 + CTA)